### PR TITLE
Don't use deprecated ParserBeforeTidy hook

### DIFF
--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -36,8 +36,7 @@ use \Html;
  * will be hardened here, through the use of {@see Html::rawElement}.
  *
  * Tested hooks to insert the deferred content:
- * * ParserBeforeTidy: Injects content anytime a parser is invoked. Including for instance the searchGoButton... :(
- * * ParserAfterTidy: Same as ParserBeforeTidy
+ * * ParserAfterTidy: Injects content anytime a parser is invoked. Including for instance the searchGoButton... :(
  * * SkinAfterContent: Works; content inside mw-data-after-content container, which trails the "mw-content-text" and the "printfooter" divs.
  *      Needs deferred content to be stored in parser cache. This runs into problems with fixed-head under chameleon 1.7.0+!
  * * OutputPageParserOutput: Works; adds either at the bottom of the content (right after the tidy remarks and the comment containing caching information)

--- a/tests/phpunit/Unit/HookRegistryTest.php
+++ b/tests/phpunit/Unit/HookRegistryTest.php
@@ -429,9 +429,9 @@ class HookRegistryTest extends PHPUnit_Framework_TestCase {
 	public function buildHookCallbackListForProvider() {
 		return [
 			'empty'               => [ [] ],
-			'default'             => [ [ 'ParserBeforeTidy', 'ParserFirstCallInit', 'SetupAfterCache', 'ScribuntoExternalLibraries' ] ],
-			'alsoImageModal'      => [ [ 'ImageBeforeProduceHTML', 'InternalParseBeforeLinks', 'ParserBeforeTidy', 'ParserFirstCallInit', 'SetupAfterCache', 'ScribuntoExternalLibraries' ] ],
-			'alsoCarouselGallery' => [ [ 'GalleryGetModes', 'ParserBeforeTidy', 'ParserFirstCallInit', 'SetupAfterCache', 'ScribuntoExternalLibraries' ] ],
+			'default'             => [ [ 'ParserAfterTidy', 'ParserFirstCallInit', 'SetupAfterCache', 'ScribuntoExternalLibraries' ] ],
+			'alsoImageModal'      => [ [ 'ImageBeforeProduceHTML', 'InternalParseBeforeLinks', 'ParserAfterTidy', 'ParserFirstCallInit', 'SetupAfterCache', 'ScribuntoExternalLibraries' ] ],
+			'alsoCarouselGallery' => [ [ 'GalleryGetModes', 'ParserAfterTidy', 'ParserFirstCallInit', 'SetupAfterCache', 'ScribuntoExternalLibraries' ] ],
 			'all'                 => [ [ 'GalleryGetModes', 'ImageBeforeProduceHTML', 'InternalParseBeforeLinks', 'ParserFirstCallInit', 'SetupAfterCache', 'ScribuntoExternalLibraries' ] ],
 			'invalid'             => [ [ 'nonExistingHook', 'PageContentSave' ] ],
 		];


### PR DESCRIPTION
Access to "untidy" parser output is being removed and this hook is being deprecated.

It is straightforward to switch to using the ParserAfterTidy hook instead.

ParserBeforeTidy deprecation in I4a0aae7b17fb522a5e4f90edad3a0b7137b270a6.