### PR TITLE
Fix Card active class

### DIFF
--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -136,7 +136,7 @@ class Card extends AbstractComponent {
 		if ( $this->isCollapsible() ) {
 			$class = [ 'card-collapse', 'collapse', 'fade' ];
 			if ( $this->getValueFor( 'active' ) ) {
-				$class[] = 'in';
+				$class[] = 'show';
 			}
 		}
 		return $class;


### PR DESCRIPTION
Fixes: #21 

The active class should be `show`, not `in`, as per the Bootstrap documentation:
https://getbootstrap.com/docs/4.6/components/collapse/#accordion-example