### PR TITLE
First steps to drop unsupported MW and PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,18 +25,19 @@ dist: trusty
 jobs:
   fast_finish: true
   include:
-    - env: DB=mysql; MW=REL1_31; TYPE=coverage; PHPUNIT=6.5.*
-      php: 7.1
-    - env: DB=mysql; MW=REL1_33; PHPUNIT=6.5.*
-      php: 7.1
-    - env: DB=mysql; MW=REL1_34; PHPUNIT=6.5.*
-      php: 7.2
     - env: DB=mysql; MW=REL1_35; PHPUNIT=7.5.*
-      php: 7.3
+      php: 7.4
+    - env: DB=mysql; MW=REL1_36; PHPUNIT=8.5.*
+      php: 7.4
+    - env: DB=mysql; MW=REL1_37; PHPUNIT=8.5.*
+      php: 7.4
+    - env: DB=mysql; MW=REL1_37; PHPUNIT=8.5.*
+      php: 8.0
     - env: DB=mysql; MW=master; PHPUNIT=8.5.*
       php: 7.4
+    - env: DB=mysql; MW=master; PHPUNIT=8.5.*
+      php: 8.0
   allow_failures:
-    - env: DB=mysql; MW=REL1_35; PHPUNIT=7.5.*
     - env: DB=mysql; MW=master; PHPUNIT=8.5.*
 
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ configuration it can add a new [gallery][Gallery] mode, and replace normal
 [image rendering][Image] with an image modal.
 
 ## Requirements
-* PHP 7.1 or later
-* MediaWiki 1.31 or later
+* PHP 7.4 or later
+* MediaWiki 1.35 or later
 
 ## Documentation
 - [Installation and configuration](docs/installation-configuration.md)
@@ -45,7 +45,7 @@ on MediaWiki.org][mw-talk]. For direct contact with the author
 please use the [Email functionality on MediaWiki.org.][mw-mail]
 
 ## Bootstrap3
-If you are using bootstrap3, please use the [legacy documentation](docs/bs3/README.md). 
+If you are using bootstrap3, please use the [legacy documentation](docs/bs3/README.md).
 
 
 [MediaWiki]: https://www.mediawiki.org/

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
 		"source": "https://github.com/oetterer/BootstrapComponents"
 	},
 	"require": {
-		"php": ">=7.1",
-		"composer/installers": "1.*,>=1.0.1",
+		"php": ">=7.4",
+		"composer/installers": "^2|^1.0.1",
 		"mediawiki/mw-extension-registry-helper": "^1.0",
 		"mediawiki/bootstrap": "~4.5"
 	},

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -11,7 +11,7 @@ the "require"-section of your `composer.local.json` file and run the
 ```
 {
 	"require": {
-		"mediawiki/bootstrap-components": "~4.0"
+		"mediawiki/bootstrap-components": "~5.0"
 	}
 }
 ```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,8 +1,16 @@
 ## Release Notes
 
-### BootstrapComponents 4.1.0
+### BootstrapComponents 5.0.0
 
 Released on _not yet_
+
+Breaking changes:
+* requires MediaWiki 1.35 or later
+* requires PHP 7.4 or later
+
+### BootstrapComponents 4.1.0
+
+Unreleased
 
 Changes:
 - setting required php version to 7.1 (which in fact it already was, since 7.1 language constructs have been used)
@@ -19,7 +27,7 @@ Released on 26-May-2021
 
 Changes:
 * add translations via translatewiki
-* bump bootstrap extension dependency to 4.5.x 
+* bump bootstrap extension dependency to 4.5.x
 
 Fixes:
 * fix travis issues, thx @malberts
@@ -99,12 +107,12 @@ Changes:
 * add two more known issues concerning the modal
 * add more robust argument and return value handling for lua parse() function
 * add issue template
-* rename namespace for components from `\BootstrapComponents\Component` to 
+* rename namespace for components from `\BootstrapComponents\Component` to
     `\BootstrapComponents\Component` to comply with naming conventions
 * introduce class `ParserFirstCallInit` that handles the hook with the same name
 
 Fixes:
-* illegal call to User->loadFromSession() triggered by Extension:CodeMirror 
+* illegal call to User->loadFromSession() triggered by Extension:CodeMirror
 
 ### BootstrapComponents 1.1.1
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "BootstrapComponents",
-	"version": "4.0.1-dev",
+	"version": "5.0.0-dev",
 	"author": [
 		"[https://www.semantic-mediawiki.org/wiki/User:Oetterer Tobias Oetterer]"
 	],
@@ -9,7 +9,7 @@
 	"license-name": "GPL-3.0-or-later",
 	"type": "parserhook",
 	"requires": {
-		"MediaWiki": ">= 1.31.0"
+		"MediaWiki": ">= 1.35.0"
 	},
 	"ConfigRegistry": {
 		"BootstrapComponents": "GlobalVarConfig::newInstance"


### PR DESCRIPTION
I haven't look at any test or code issues yet, but with issues like https://github.com/oetterer/BootstrapComponents/issues/31 coming up we need to start dropping unsupported versions.