### PR TITLE
Remove unused variable

### DIFF
--- a/src/ImageModalTrigger.php
+++ b/src/ImageModalTrigger.php
@@ -406,8 +406,6 @@ class ImageModalTrigger {
 	 */
 	private function getWidthOptionForThumbLimits( array $thumbLimits ) {
 
-		// this could also be affected by issue #9
-		$user = RequestContext::getMain()->getUser();
 		$widthOption = MediaWikiServices::getInstance()->getUserOptionsLookup()->getDefaultOption( 'thumbsize' );
 
 		// we have a problem here: the original \Linker::makeImageLink does get a value for $widthOption,


### PR DESCRIPTION
This is a very minor issue I caught when reading 158233f16f34feda8928409a071d9e79ae90e24d (we saw an internal error on MW 1.38 on January in this function getWidthOptionForThumbLimits, fixed by the mentionned commit).