### PR TITLE
Support future version of Bootstrap extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"php": ">=7.4",
 		"composer/installers": "^2|^1.0.1",
 		"mediawiki/mw-extension-registry-helper": "^1.0",
-		"mediawiki/bootstrap": "^4.0"
+		"mediawiki/bootstrap": "^5.0|^4.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "43.0.0",


### PR DESCRIPTION
I'm busy cleaning up Chameleon/Bootstrap/SCSS and adding support/tests for newer version of Mediawiki (1.42, master).

That is greatly simplified by dropping support for MW <1.39 and PHP <8.0. So part of that is to release a new major version of Bootstrap/SCSS.

This PR just changes the composer dependency version to support the new Bootstrap extension version.