### PR TITLE
Update I18nJsonFileIntegrityTest.php to use namespaced class

### DIFF
--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -16,7 +16,7 @@ use SMW\Tests\Utils\UtilityFactory;
  * @author mwjames
  * @author Tobias Oetterer
  */
-class I18nJsonFileIntegrityTest extends \PHPUnit\Framework\TestCase {
+class I18nJsonFileIntegrityTest extends PHPUnit\Framework\TestCase {
 
 	use PHPUnitCompat;
 

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -16,7 +16,7 @@ use SMW\Tests\Utils\UtilityFactory;
  * @author mwjames
  * @author Tobias Oetterer
  */
-class I18nJsonFileIntegrityTest extends PHPUnit\Framework\TestCase {
+class I18nJsonFileIntegrityTest extends \PHPUnit\Framework\TestCase {
 
 	use PHPUnitCompat;
 

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -16,7 +16,7 @@ use SMW\Tests\Utils\UtilityFactory;
  * @author mwjames
  * @author Tobias Oetterer
  */
-class I18nJsonFileIntegrityTest extends \PHPUnit_Framework_TestCase {
+class I18nJsonFileIntegrityTest extends \PHPUnit\Framework\TestCase {
 
 	use PHPUnitCompat;
 


### PR DESCRIPTION
Since v6 of PHPUnit, the classes are fully namespaced rather than namespaced by the underscore convention.