### PR TITLE
Add tests to Database group

### DIFF
--- a/tests/phpunit/Unit/LuaLibraryGetSkinTest.php
+++ b/tests/phpunit/Unit/LuaLibraryGetSkinTest.php
@@ -7,7 +7,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
  * @ingroup Test
  *
  * @group   extension-bootstrap-components
- * @group   mediawiki-databaseless
+ * @group   Database
  *
  * @license GNU GPL v3+
  *

--- a/tests/phpunit/Unit/LuaLibraryParseTest.php
+++ b/tests/phpunit/Unit/LuaLibraryParseTest.php
@@ -7,7 +7,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
  * @ingroup Test
  *
  * @group   extension-bootstrap-components
- * @group   mediawiki-databaseless
+ * @group   Database
  *
  * @license GNU GPL v3+
  *

--- a/tests/phpunit/Unit/LuaLibraryTest.php
+++ b/tests/phpunit/Unit/LuaLibraryTest.php
@@ -7,6 +7,8 @@ use MediaWiki\Extension\BootstrapComponents\LuaLibrary;
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\LuaLibrary
  *
+ * @group   Database
+ *
  * @license GNU GPL v2+
  * @since   1.1
  *

--- a/tests/phpunit/Unit/LuaLibraryTestBase.php
+++ b/tests/phpunit/Unit/LuaLibraryTestBase.php
@@ -9,7 +9,6 @@ use \Scribunto_LuaEngineTestBase;
  * @ingroup Test
  *
  * @group   extension-bootstrap-components
- * @group   mediawiki-databaseless
  *
  * @license GNU GPL v3+
  *


### PR DESCRIPTION
Follow-up to #59 

It looks like at some point the Scribunto base test classes might have started to use the DB. Doesn't seem worth the time to figure out what changed when the group change is good enough.

master failures are expected. Fixing the namespace issues there will require dropping MW 1.39 support.