### PR TITLE
Fix TypeError in ImageModal when file does not exist

### DIFF
--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -140,6 +140,9 @@ class HooksHandler implements
 	): bool {
 		if ( $this->getConfig()->has( 'BootstrapComponentsModalReplaceImageTag' ) &&
 			$this->getConfig()->get( 'BootstrapComponentsModalReplaceImageTag' ) ) {
+			if ( !$file ) {
+				return true;
+			}
 			$imageModal = new ImageModal( $linker, $title, $file,
 				$this->getNestingController(), $this->getBootstrapComponentsService()
 			);


### PR DESCRIPTION
## Summary

- When `$wgBootstrapComponentsModalReplaceImageTag` is enabled and a page references a non-existent file, `onImageBeforeProduceHTML` passes `false` for `$file` to `ImageModal::__construct()`, which has a strict `File` type hint → TypeError
- Adds a guard to skip modal replacement when `$file` is `false`, letting MediaWiki render its normal missing-file link

Fixes #71