### PR TITLE
Migrate to Bootstrap 5.3 and resolve modal/popover/tooltip lifecycle bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,32 +13,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_39'
-            php: 8.0
-            type: coverage
-            experimental: false
-          - mw: 'REL1_39'
+          - mw: 'REL1_43'
             php: 8.1
+            # TODO: Scrutinzer Ocular overage disabled due to https://github.com/scrutinizer-ci/ocular/issues/51
             type: normal
-            experimental: false
-          - mw: 'REL1_40'
-            php: 8.1
-            type: normal
-            experimental: false
-          - mw: 'REL1_41'
-            php: 8.1
-            type: normal
-            experimental: false
-          - mw: 'REL1_42'
+            experimental: true
+          - mw: 'REL1_44'
             php: 8.2
             type: normal
             experimental: false
-          - mw: 'REL1_43'
+          - mw: 'REL1_45'
             php: 8.3
+            type: normal
+            experimental: false
+          - mw: 'master'
+            php: 8.4
             type: normal
             experimental: true
           - mw: 'master'
-            php: 8.4
+            php: 8.5
             type: normal
             experimental: true
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,8 +14,9 @@ tools:
     php_loc: true
     php_analyzer: true
     sensiolabs_security_checker: true
-    external_code_coverage:
-        timeout: '1200' # timeout in seconds
+    # TODO: Scrutinzer Ocular overage disabled due to https://github.com/scrutinizer-ci/ocular/issues/51
+    # external_code_coverage:
+    #    timeout: '1200' # timeout in seconds
 
 checks:
     php:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Bootstrap Components is a [MediaWiki] extension that aims to provide
 editors with easy access to certain components introduced by
-[Twitter Bootstrap 4][Bootstrap].
+[Twitter Bootstrap 5][Bootstrap].
 
 Depending on your configuration, editors can utilize several
 _tag extensions_ and _parser functions_ inside wiki code to place certain
@@ -16,8 +16,8 @@ configuration it can add a new [gallery][Gallery] mode, and replace normal
 [image rendering][Image] with an image modal.
 
 ## Requirements
-* PHP 8.0 or later
-* MediaWiki 1.39 or later
+* PHP 8.1 or later
+* MediaWiki 1.43 or later
 
 ## Documentation
 - [Installation and configuration](docs/installation-configuration.md)
@@ -31,8 +31,9 @@ configuration it can add a new [gallery][Gallery] mode, and replace normal
 
 Please also see the [known issues][known-issues] section.
 
-There is also a [migration guide](docs/migration-guide.md) for users switching
-from bootstrap3 (BootstrapComponents ~1.2) to bootstrap4 (BootstrapComponents ~4.0).
+There is also a [migration guide](docs/migration-guide.md) for users switching between versions:
+- Bootstrap 3 → Bootstrap 4: BootstrapComponents ~1.2 → ~4.0
+- Bootstrap 4 → Bootstrap 5: BootstrapComponents ~5.x → ~6.0
 
 ## Contact
 For bug reports and feature requests, please see if it is already reported on

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,15 @@
 		"source": "https://github.com/oetterer/BootstrapComponents"
 	},
 	"require": {
-		"php": ">=8.0",
+		"php": ">=8.1",
 		"composer/installers": "^2|^1.0.1",
-		"mediawiki/bootstrap": "^5.0"
+		"mediawiki/bootstrap": "^6.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "46.0.0",
-    "mediawiki/mediawiki-phan-config": "0.15.1",
+		"mediawiki/mediawiki-phan-config": "0.15.1",
 		"phpmd/phpmd": "~2.1",
-		"php": ">=8.0"
+		"php": ">=8.1"
 	},
 	"suggest": {
 		"mediawiki/scribunto": "Framework for embedding scripting languages into MediaWiki pages"
@@ -58,5 +58,10 @@
 			"composer phpunit",
 			"composer cs"
 		]
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "6.x-dev"
+		}
 	}
 }

--- a/docs/components.md
+++ b/docs/components.md
@@ -22,6 +22,9 @@ the following components are available to be used inside the wiki text:
   want to hide and show large amount of content.
 * **[Jumbotron](components/jumbotron.md)**: A jumbotron indicates a big
   box for calling extra attention to some special content or information.
+  _Bootstrap 5 removed `.jumbotron`; the parser function is retained
+  (now emitting BS5 utility classes) but is deprecated and may be removed
+  in a future release._
 * **[Modal](components/modal.md)**: The Modal component is a dialog
   box/popup window that is displayed on top of the current page.
 * **[Popover](components/popover.md)**: The Popover component produces a

--- a/docs/components/accordion.md
+++ b/docs/components/accordion.md
@@ -40,6 +40,6 @@ add multiple css styles, separate them by a semicolon.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/collapse/#accordion-example
+* https://getbootstrap.com/docs/5.3/components/collapse/#accordion-example
 * https://www.w3schools.com/bootstrap4/bootstrap_collapse.asp
 

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -54,6 +54,6 @@ add multiple css styles, separate them by a semicolon.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/alerts/
+* https://getbootstrap.com/docs/5.3/components/alerts/
 * https://www.w3schools.com/bootstrap4/bootstrap_alerts.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/utilities/colors/

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -24,7 +24,7 @@ add multiple classes, separate them by a space.</dd>
 
 Allowed Values are
 <ul>
-<li>default</li>
+<li>default <i>(maps to <code>secondary</code> under Bootstrap 5)</i></li>
 <li>primary</li>
 <li>secondary</li>
 <li>success</li>
@@ -52,7 +52,7 @@ add multiple css styles, separate them by a semicolon.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/badge/
+* https://getbootstrap.com/docs/5.3/components/badge/
 * https://www.w3schools.com/bootstrap4/bootstrap_badges.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/utilities/colors/
 *

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -26,7 +26,7 @@ add multiple classes, separate them by a space.</dd>
 
 Allowed Values are
 <ul>
-<li>default</li>
+<li>default <i>(maps to <code>secondary</code> under Bootstrap 5)</i></li>
 <li>primary</li>
 <li>secondary</li>
 <li>success</li>
@@ -78,7 +78,7 @@ background with button color.</dd>
 
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/buttons/
+* https://getbootstrap.com/docs/5.3/components/buttons/
 * https://www.w3schools.com/bootstrap4/bootstrap_buttons.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/utilities/colors/
 *

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -109,6 +109,6 @@ add multiple css styles, separate them by a semicolon.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/card/
+* https://getbootstrap.com/docs/5.3/components/card/
 * https://www.w3schools.com/bootstrap4/bootstrap_cards.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/utilities/colors/

--- a/docs/components/carousel.md
+++ b/docs/components/carousel.md
@@ -38,5 +38,5 @@ attributes, otherwise the parser will drop all but one:
 ```
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/carousel/
+* https://getbootstrap.com/docs/5.3/components/carousel/
 * https://www.w3schools.com/bootstrap4/bootstrap_carousel.asp

--- a/docs/components/collapse.md
+++ b/docs/components/collapse.md
@@ -29,5 +29,5 @@ be used as the trigger element. In this case, all but the attributes
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/collapse/
+* https://getbootstrap.com/docs/5.3/components/collapse/
 * https://www.w3schools.com/bootstrap4/bootstrap_collapse.asp

--- a/docs/components/jumbotron.md
+++ b/docs/components/jumbotron.md
@@ -1,9 +1,19 @@
 ## Jumbotron
+
+> **⚠️ Deprecated.** Bootstrap 5 removed the `.jumbotron` component. The
+> `bootstrap_jumbotron` parser function is retained for backward compatibility
+> and now emits the equivalent Bootstrap 5 utility-class combination
+> (`p-5 mb-4 bg-body-tertiary rounded-3`) per the official migration guide.
+> New content should prefer composing utility classes directly. The parser
+> function may be removed in a future major release.
+
 A jumbotron indicates a big box for calling extra attention to some special
 content or information.
 
-A jumbotron is displayed as a grey box with rounded corners. It also enlarges
-the font sizes of the text inside it.
+A jumbotron is displayed as a light box with rounded corners. The Bootstrap 4
+version also enlarged the font sizes of the text inside it; the Bootstrap 5
+utility-class approximation does not — apply `display-*` utility classes to the
+contained headings if you want the BS4-era larger-font look.
 
 See also:
 * [Alert](alert.md)
@@ -33,5 +43,5 @@ add multiple css styles, separate them by a semicolon.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/jumbotron/
+* https://getbootstrap.com/docs/5.3/migration/#jumbotron
 * https://www.w3schools.com/bootstrap4/bootstrap_jumbotron.asp

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -31,7 +31,7 @@ add multiple classes, separate them by a space.</dd>
 
 Allowed Values are
 <ul>
-<li>default</li>
+<li>default <i>(maps to <code>secondary</code> under Bootstrap 5)</i></li>
 <li>primary</li>
 <li>secondary</li>
 <li>success</li>
@@ -76,8 +76,8 @@ be used as the trigger element.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/modal/
+* https://getbootstrap.com/docs/5.3/components/modal/
 * https://www.w3schools.com/bootstrap4/bootstrap_modal.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/utilities/colors/
 
 Please, see also the [known issues](../known-issues.md) with this component.

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -26,7 +26,7 @@ add multiple classes, separate them by a space.</dd>
 
 Allowed Values are
 <ul>
-<li>default</li>
+<li>default <i>(maps to <code>secondary</code> under Bootstrap 5)</i></li>
 <li>primary</li>
 <li>secondary</li>
 <li>success</li>
@@ -94,6 +94,6 @@ behaviour with:
 
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/popovers/
+* https://getbootstrap.com/docs/5.3/components/popovers/
 * https://www.w3schools.com/bootstrap4/bootstrap_popover.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/utilities/colors/

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -51,5 +51,5 @@ following to your `Mediawiki:Common.css`:
 ```
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/tooltips/
+* https://getbootstrap.com/docs/5.3/components/tooltips/
 * https://www.w3schools.com/bootstrap4/bootstrap_tooltip.asp

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -2,6 +2,15 @@
 Some components cause problems with other components or "external"
 elements.
 
+> **Note for Bootstrap 5 (BootstrapComponents 6.0):**
+> A long-standing class of issues affecting Modal/Popover/Tooltip components
+> under MediaWiki 1.43+ (upstream issue [#68][issue-68] — "stop working after
+> a cache purge") was resolved in 6.0 by emitting modal markup inline next to
+> its trigger instead of relying on the `ParserOutput::setExtensionData` /
+> `OutputPageParserOutput` deferred-injection mechanism. If you saw any of the
+> earlier "modal does not open" / "popover does nothing" symptoms under MW
+> 1.43, those should now be fixed.
+
 ### Modals and popovers
 When you put popovers on a page with modals (or image modals),
 the modals break.
@@ -41,3 +50,5 @@ simply "push" the modal further down. For example:
     top: 60px;
 }
 ```
+
+[issue-68]: https://github.com/oetterer/BootstrapComponents/issues/68

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,7 +1,97 @@
 ## Migration Guide
 
+### Migrating from Bootstrap 4 (BootstrapComponents 5.x) to Bootstrap 5 (BootstrapComponents 6.0)
+
+BootstrapComponents 6.0 upgrades the underlying Bootstrap framework from version 4 to version 5.3. This guide helps you understand the changes and migrate your wiki.
+
+#### System Requirements
+- **MediaWiki:** 1.43 or later (upgraded from 1.39)
+- **PHP:** 8.1 or later (upgraded from 8.0)
+- **Bootstrap Extension:** mediawiki/bootstrap 6.x-dev from [ProfessionalWiki/Bootstrap](https://github.com/ProfessionalWiki/Bootstrap)
+
+#### User Impact
+**Good News:** Most existing wiki markup using BootstrapComponents should continue to work without any changes! The extension handles most Bootstrap 5 migrations internally.
+
+#### Component Changes
+
+##### Jumbotron
+The Jumbotron component still works but now uses Bootstrap 5 utility classes instead of the removed `.jumbotron` class. The visual appearance should be similar but may have minor differences. Consider:
+- Using utility classes directly: `<div class="p-5 mb-4 bg-body-tertiary rounded-3">`
+- Or continue using `<bootstrap_jumbotron>` tag which is now implemented using these utilities
+- Reference: https://getbootstrap.com/docs/5.3/examples/jumbotron/
+
+##### Button Colors
+The `color="default"` attribute is automatically mapped to `color="secondary"` in Bootstrap 5. If you prefer different colors:
+- Use `color="light"` for light gray buttons
+- Use `color="secondary"` explicitly for the standard secondary color
+
+##### Badge Pill
+If you're using custom CSS targeting `.badge-pill`, update to `.rounded-pill`:
+```css
+/* Old */
+.badge-pill { ... }
+
+/* New */
+.rounded-pill { ... }
+```
+
+##### Alert and Modal Close Buttons
+Close buttons now use Bootstrap 5's `.btn-close` class. If you have custom CSS targeting `.close`:
+```css
+/* Old */
+.close { ... }
+
+/* New */
+.btn-close { ... }
+```
+
+#### JavaScript Changes
+Bootstrap 5 removed jQuery dependency. If you have custom JavaScript interacting with Bootstrap components:
+
+**Old (Bootstrap 4 + jQuery):**
+```javascript
+$('.carousel').carousel();
+$('[data-toggle="tooltip"]').tooltip();
+```
+
+**New (Bootstrap 5 vanilla JS):**
+```javascript
+document.querySelectorAll('.carousel').forEach(el => {
+    new bootstrap.Carousel(el);
+});
+document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+    new bootstrap.Tooltip(el);
+});
+```
+
+#### Data Attributes
+If you're using custom HTML with Bootstrap data attributes, update to the `data-bs-*` prefix:
+- `data-toggle` → `data-bs-toggle`
+- `data-target` → `data-bs-target`
+- `data-dismiss` → `data-bs-dismiss`
+- `data-slide` → `data-bs-slide`
+- `data-parent` → `data-bs-parent`
+- `data-content` → `data-bs-content`
+- `data-placement` → `data-bs-placement`
+- `data-trigger` → `data-bs-trigger`
+
+#### Testing Your Upgrade
+After upgrading:
+1. Test all pages using BootstrapComponents
+2. Verify modals, tooltips, popovers, and carousels work correctly
+3. Check custom CSS for compatibility
+4. Test any custom JavaScript interacting with Bootstrap
+5. Verify with different MediaWiki skins (Vector, Vector-2022)
+
+#### Rollback
+If you encounter issues, you can rollback to BootstrapComponents 5.x which uses Bootstrap 4.
+
+---
+
+### Migrating from Bootstrap 3 (BootstrapComponents 1.x) to Bootstrap 4 (BootstrapComponents 4.x-5.x)
+
 There have been some changes between versions ~1.0 and ~4.0. Foremost is that
-the new BootstrapComponents utilizes Twitter Bootstrap4. Therefore, it mirrors
+the new BootstrapComponents utilizes Twitter Bootstrap 4. Therefore, it mirrors
 changes made by Bootstrap.
 
 Also, extension loading must now be done manually in your LocalSettings, no

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -7,7 +7,7 @@ BootstrapComponents 6.0 upgrades the underlying Bootstrap framework from version
 #### System Requirements
 - **MediaWiki:** 1.43 or later (upgraded from 1.39)
 - **PHP:** 8.1 or later (upgraded from 8.0)
-- **Bootstrap Extension:** mediawiki/bootstrap 6.x-dev from [ProfessionalWiki/Bootstrap](https://github.com/ProfessionalWiki/Bootstrap)
+- **Bootstrap Extension:** mediawiki/bootstrap ^6.0 from [ProfessionalWiki/Bootstrap](https://github.com/ProfessionalWiki/Bootstrap)
 
 #### User Impact
 **Good News:** Most existing wiki markup using BootstrapComponents should continue to work without any changes! The extension handles most Bootstrap 5 migrations internally.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,11 +21,17 @@ Released on _TBD_
   - `data-placement` → `data-bs-placement`
   - `data-trigger` → `data-bs-trigger`
 * JavaScript modules migrated from jQuery to vanilla JavaScript (Bootstrap 5 requirement)
-* Badge component: `badge-pill` class changed to `rounded-pill`
+* Badge component: `badge-pill` class changed to `rounded-pill`; `badge-<color>` family replaced with `text-bg-<color>` per the BS5 migration guide; `color="default"` now maps to `text-bg-secondary` for backward-compat
 * Button component: `btn-default` automatically mapped to `btn-secondary`
 * Alert and Modal close buttons: Migrated from `.close` class with `&times;` character to `.btn-close` class
 * Jumbotron component: Recreated using Bootstrap 5 utility classes (`p-5 mb-4 bg-body-tertiary rounded-3`); the parser function is retained for compatibility but is now `@deprecated`
 * All CSS fixes reviewed and updated for Bootstrap 5 compatibility
+
+**Bug fixes (also benefit users on MediaWiki 1.43+ even without BS5 markup changes):**
+* Modal, Popover and Tooltip components now actually trigger under MediaWiki 1.43+. The previous architecture relied on `ParserOutput::setExtensionData` carrying deferred modal markup from parse-time to the `OutputPageParserOutput` hook callback; MW 1.43+'s `ParserOutputAccess` lifecycle no longer preserves this. Modal markup is now emitted inline next to its trigger button, which works regardless of MW version. Closes upstream issue [#68](https://github.com/oetterer/BootstrapComponents/issues/68).
+* Tooltip JS module's `DOMContentLoading` typo (should be `DOMContentLoaded`) fixed.
+* Modal trigger received a new ResourceLoader JS module that explicitly instantiates `bootstrap.Modal` on each `.modal` element (BS5 no longer auto-initialises modal triggers the way BS4 + jQuery did).
+* `OutputPageParserOutput` hook now also loads the BC component JS modules via `OutputPage::addModules()` — previously these were declared with a `scripts` key but only added via `addModuleStyles()`, which never loaded their JS.
 
 **User Impact:**
 * Most existing wiki markup using BootstrapComponents should continue to work without changes

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,39 @@
 ## Release Notes
 
+### BootstrapComponents 6.0.0
+
+Released on _TBD_
+
+**BREAKING CHANGES:**
+* Requires MediaWiki 1.43 or later (upgraded from 1.39)
+* Requires PHP 8.1 or later (upgraded from 8.0)
+* Upgraded from Bootstrap 4 to Bootstrap 5.3
+* Changed Bootstrap dependency from `mediawiki/bootstrap ^5.0` to `mediawiki/bootstrap ^6.0`
+
+**Bootstrap 5 Migration Changes:**
+* All data attributes updated to Bootstrap 5 format with `data-bs-*` prefix:
+  - `data-toggle` → `data-bs-toggle`
+  - `data-target` → `data-bs-target`
+  - `data-dismiss` → `data-bs-dismiss`
+  - `data-slide` → `data-bs-slide`
+  - `data-parent` → `data-bs-parent`
+  - `data-content` → `data-bs-content`
+  - `data-placement` → `data-bs-placement`
+  - `data-trigger` → `data-bs-trigger`
+* JavaScript modules migrated from jQuery to vanilla JavaScript (Bootstrap 5 requirement)
+* Badge component: `badge-pill` class changed to `rounded-pill`
+* Button component: `btn-default` automatically mapped to `btn-secondary`
+* Alert and Modal close buttons: Migrated from `.close` class with `&times;` character to `.btn-close` class
+* Jumbotron component: Recreated using Bootstrap 5 utility classes (`p-5 mb-4 bg-body-tertiary rounded-3`); the parser function is retained for compatibility but is now `@deprecated`
+* All CSS fixes reviewed and updated for Bootstrap 5 compatibility
+
+**User Impact:**
+* Most existing wiki markup using BootstrapComponents should continue to work without changes
+* JavaScript initialization now uses Bootstrap 5 native API
+* Custom CSS may need review if it targets Bootstrap 4-specific classes
+
+See [migration guide](migration-guide.md) for detailed upgrade instructions.
+
 ### BootstrapComponents 5.2.2
 
 Released on 01-April-2026

--- a/extension.json
+++ b/extension.json
@@ -1,13 +1,13 @@
 {
 	"name": "BootstrapComponents",
-	"version": "5.2.2",
+	"version": "6.0.0-dev",
 	"author": [ "Tobias Oetterer" ],
 	"url": "https://www.mediawiki.org/wiki/Extension:BootstrapComponents",
 	"descriptionmsg": "bootstrap-components-desc",
 	"license-name": "GPL-3.0-or-later",
 	"type": "parserhook",
 	"requires": {
-		"MediaWiki": ">= 1.39.0"
+		"MediaWiki": ">= 1.43.0"
 	},
 	"ConfigRegistry": {
 		"BootstrapComponents": "GlobalVarConfig::newInstance"

--- a/extension.json
+++ b/extension.json
@@ -109,7 +109,9 @@
 			"scripts": "ext.bootstrapComponents.carousel.js"
 		},
 		"ext.bootstrapComponents.modal.fix": {
-			"styles": "ext.bootstrapComponents.modal.fix.css"
+			"dependencies": "ext.bootstrap.scripts",
+			"styles": "ext.bootstrapComponents.modal.fix.css",
+			"scripts": "ext.bootstrapComponents.modal.js"
 		},
 		"ext.bootstrapComponents.modal.vector-fix": {
 			"styles": "ext.bootstrapComponents.modal.vector-fix.css"

--- a/modules/ext.bootstrapComponents.button.fix.css
+++ b/modules/ext.bootstrapComponents.button.fix.css
@@ -25,12 +25,8 @@
 
 /*
  * a href prioritizes the mw link color. overwrite this here to a more suitable one
+ * Bootstrap 5: btn-default removed
  */
-a.btn-default,
-a.btn-default:link,
-a.btn-default:visited,
-a.btn-default:active,
-a.btn-default:hover,
 a.btn-light,
 a.btn-light:link,
 a.btn-light:visited,
@@ -79,19 +75,15 @@ a.btn-dark:hover {
 
 /**
  * outline link colors have to be defined separately
+ * Bootstrap 5: btn-outline-default removed
  */
 
-a.btn-outline-default,
-a.btn-outline-default:link,
-a.btn-outline-default:visited,
-a.btn-outline-default:active,
 a.btn-outline-light,
 a.btn-outline-light:link,
 a.btn-outline-light:visited,
 a.btn-outline-light:active {
 	color: var(--white);
 }
-a.btn-outline-default:hover,
 a.btn-outline-light:hover {
 	color: #212529;
 }

--- a/modules/ext.bootstrapComponents.carousel.js
+++ b/modules/ext.bootstrapComponents.carousel.js
@@ -1,5 +1,7 @@
 /**
- * Contains javascript code executed when tooltips are used.
+ * Contains javascript code executed when carousels are used.
+ *
+ * Bootstrap 5 migration: Converted from jQuery to vanilla JavaScript.
  *
  * @copyright (C) 2018, Tobias Oetterer, Paderborn University
  * @license       https://www.gnu.org/licenses/gpl-3.0.html GNU General Public License, version 3 (or later)
@@ -23,6 +25,24 @@
  * @author        Tobias Oetterer
  */
 
-$(function () {
-	$('.carousel').carousel();
-});
+( function () {
+	'use strict';
+
+	// Wait for DOM to be ready
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initCarousels );
+	} else {
+		initCarousels();
+	}
+
+	function initCarousels() {
+		// Bootstrap 5 automatically initializes carousels with data-bs-ride="carousel"
+		// Manual initialization for additional control
+		var carouselElements = document.querySelectorAll( '.carousel' );
+		carouselElements.forEach( function ( element ) {
+			if ( typeof bootstrap !== 'undefined' && bootstrap.Carousel ) {
+				new bootstrap.Carousel( element );
+			}
+		} );
+	}
+}() );

--- a/modules/ext.bootstrapComponents.modal.js
+++ b/modules/ext.bootstrapComponents.modal.js
@@ -1,0 +1,51 @@
+/**
+ * Contains javascript code executed when modals are used.
+ *
+ * Bootstrap 5 migration: BS5 dropped the jQuery `.modal()` plugin, and
+ * modal triggers (elements with `data-bs-toggle="modal"`) are no longer
+ * auto-initialised the way BS4 did. Instantiate a `bootstrap.Modal` for each
+ * modal container so the data-attribute triggers will actually open it.
+ *
+ * @copyright (C) 2018, Tobias Oetterer, Paderborn University
+ * @license       https://www.gnu.org/licenses/gpl-3.0.html GNU General Public License, version 3 (or later)
+ *
+ * This file is part of the MediaWiki extension BootstrapComponents.
+ * The BootstrapComponents extension is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The BootstrapComponents extension is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @file
+ * @ingroup       BootstrapComponents
+ * @author        Tobias Oetterer
+ */
+
+( function () {
+	'use strict';
+
+	// Wait for DOM to be ready
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initModals );
+	} else {
+		initModals();
+	}
+
+	function initModals() {
+		// Instantiate every .modal element so trigger clicks (or programmatic
+		// bootstrap.Modal.getOrCreateInstance(el).show()) work as expected.
+		var modalList = document.querySelectorAll( '.modal' );
+		modalList.forEach( function ( modalEl ) {
+			if ( typeof bootstrap !== 'undefined' && bootstrap.Modal ) {
+				bootstrap.Modal.getOrCreateInstance( modalEl );
+			}
+		} );
+	}
+}() );

--- a/modules/ext.bootstrapComponents.popover.js
+++ b/modules/ext.bootstrapComponents.popover.js
@@ -1,6 +1,8 @@
 /**
  * Contains javascript code executed when popovers are used.
  *
+ * Bootstrap 5 migration: Converted from jQuery to vanilla JavaScript.
+ *
  * @copyright (C) 2018, Tobias Oetterer, Paderborn University
  * @license       https://www.gnu.org/licenses/gpl-3.0.html GNU General Public License, version 3 (or later)
  *
@@ -22,11 +24,26 @@
  * @ingroup       BootstrapComponents
  * @author        Tobias Oetterer
  */
-$( function() {
-    $(document).ready(function(){
-            $('[data-toggle="popover"]').popover({
-                html: true
-            });
-        });
-    }
-);
+
+( function () {
+	'use strict';
+
+	// Wait for DOM to be ready
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initPopovers );
+	} else {
+		initPopovers();
+	}
+
+	function initPopovers() {
+		// Initialize all popovers with HTML enabled (Bootstrap 5 vanilla JS API)
+		var popoverTriggerList = document.querySelectorAll( '[data-bs-toggle="popover"]' );
+		popoverTriggerList.forEach( function ( popoverTriggerEl ) {
+			if ( typeof bootstrap !== 'undefined' && bootstrap.Popover ) {
+				new bootstrap.Popover( popoverTriggerEl, {
+					html: true
+				} );
+			}
+		} );
+	}
+}() );

--- a/modules/ext.bootstrapComponents.tooltip.js
+++ b/modules/ext.bootstrapComponents.tooltip.js
@@ -30,7 +30,7 @@
 
 	// Wait for DOM to be ready
 	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoading', initTooltips );
+		document.addEventListener( 'DOMContentLoaded', initTooltips );
 	} else {
 		initTooltips();
 	}

--- a/modules/ext.bootstrapComponents.tooltip.js
+++ b/modules/ext.bootstrapComponents.tooltip.js
@@ -1,6 +1,8 @@
 /**
  * Contains javascript code executed when tooltips are used.
  *
+ * Bootstrap 5 migration: Converted from jQuery to vanilla JavaScript.
+ *
  * @copyright (C) 2018, Tobias Oetterer, Paderborn University
  * @license       https://www.gnu.org/licenses/gpl-3.0.html GNU General Public License, version 3 (or later)
  *
@@ -23,9 +25,23 @@
  * @author        Tobias Oetterer
  */
 
-$( function() {
-    $(document).ready(function(){
-            $('[data-toggle="tooltip"]').tooltip();
-        });
-    }
-);
+( function () {
+	'use strict';
+
+	// Wait for DOM to be ready
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoading', initTooltips );
+	} else {
+		initTooltips();
+	}
+
+	function initTooltips() {
+		// Initialize all tooltips with Bootstrap 5 vanilla JS API
+		var tooltipTriggerList = document.querySelectorAll( '[data-bs-toggle="tooltip"]' );
+		tooltipTriggerList.forEach( function ( tooltipTriggerEl ) {
+			if ( typeof bootstrap !== 'undefined' && bootstrap.Tooltip ) {
+				new bootstrap.Tooltip( tooltipTriggerEl );
+			}
+		} );
+	}
+}() );

--- a/src/AbstractComponent.php
+++ b/src/AbstractComponent.php
@@ -26,7 +26,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use \MWException;
+use MWException;
 
 /**
  * Class AbstractComponent

--- a/src/BootstrapComponents.php
+++ b/src/BootstrapComponents.php
@@ -43,7 +43,6 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use ConfigException;
 use Exception;
 use MWException;
 

--- a/src/BootstrapComponents.php
+++ b/src/BootstrapComponents.php
@@ -55,8 +55,6 @@ use MWException;
  */
 class BootstrapComponents {
 
-	const EXTENSION_DATA_DEFERRED_CONTENT_KEY = 'bsc_deferredContent';
-
 	const EXTENSION_DATA_NO_IMAGE_MODAL = 'bsc_no_image_modal';
 
 

--- a/src/CarouselGallery.php
+++ b/src/CarouselGallery.php
@@ -26,10 +26,10 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use MediaWiki\Extension\BootstrapComponents\Components\Carousel;
 use ImageGalleryBase;
+use MediaWiki\Extension\BootstrapComponents\Components\Carousel;
 use MediaWiki\MediaWikiServices;
-use Title;
+use MediaWiki\Title\Title;
 
 /**
  * Class CarouselGallery

--- a/src/ComponentLibrary.php
+++ b/src/ComponentLibrary.php
@@ -26,8 +26,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use MediaWiki\MediaWikiServices;
-use \MWException;
+use MWException;
 
 /**
  * Class ComponentLibrary

--- a/src/Components/Accordion.php
+++ b/src/Components/Accordion.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Accordion

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Alert

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -109,18 +109,11 @@ class Alert extends AbstractComponent {
 		return Html::rawElement(
 			'button',
 			[
-				'type'         => 'button',
-				'class'        => 'close',
-				'data-dismiss' => 'alert',
-				'aria-label'   => wfMessage( 'bootstrap-components-close-element' )->inContentLanguage()->text(),
-			],
-			Html::rawElement(
-				'span',
-				[
-					'aria-hidden' => 'true',
-				],
-				'&times;'
-			)
+				'type'            => 'button',
+				'class'           => 'btn-close',
+				'data-bs-dismiss' => 'alert',
+				'aria-label'      => wfMessage( 'bootstrap-components-close-element' )->inContentLanguage()->text(),
+			]
 		);
 	}
 }

--- a/src/Components/Badge.php
+++ b/src/Components/Badge.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Badge

--- a/src/Components/Badge.php
+++ b/src/Components/Badge.php
@@ -72,7 +72,7 @@ class Badge extends AbstractComponent {
 		$class = [ 'badge' ];
 
 		if ( (bool)$this->getValueFor( 'pill' ) ) {
-			$class[] = 'badge-pill';
+			$class[] = 'rounded-pill';
 		}
 
 		$class[] = 'badge-' . $this->getValueFor( 'color', 'primary' );

--- a/src/Components/Badge.php
+++ b/src/Components/Badge.php
@@ -75,7 +75,10 @@ class Badge extends AbstractComponent {
 			$class[] = 'rounded-pill';
 		}
 
-		$class[] = 'badge-' . $this->getValueFor( 'color', 'primary' );
+		// Bootstrap 5 dropped the `.badge-<color>` family in favour of
+		// `.text-bg-<color>` (which sets background-color AND a contrasting
+		// foreground color). See https://getbootstrap.com/docs/5.3/migration/.
+		$class[] = 'text-bg-' . $this->getValueFor( 'color', 'primary' );
 		return $class;
 	}
 }

--- a/src/Components/Badge.php
+++ b/src/Components/Badge.php
@@ -78,7 +78,13 @@ class Badge extends AbstractComponent {
 		// Bootstrap 5 dropped the `.badge-<color>` family in favour of
 		// `.text-bg-<color>` (which sets background-color AND a contrasting
 		// foreground color). See https://getbootstrap.com/docs/5.3/migration/.
-		$class[] = 'text-bg-' . $this->getValueFor( 'color', 'primary' );
+		// `color="default"` maps to `text-bg-secondary` for backward-compat
+		// with BS3-era markup (see also Button/Modal/Popover).
+		$color = $this->getValueFor( 'color', 'primary' );
+		if ( $color === 'default' ) {
+			$color = 'secondary';
+		}
+		$class[] = 'text-bg-' . $color;
 		return $class;
 	}
 }

--- a/src/Components/Button.php
+++ b/src/Components/Button.php
@@ -106,7 +106,12 @@ class Button extends AbstractComponent {
 		if ( (bool)$this->getValueFor( 'outline' ) ) {
 			$colorClass .= 'outline-';
 		}
-		$class[] = $colorClass . $this->getValueFor( 'color', 'primary' );
+		// Bootstrap 5 doesn't have btn-default, map to btn-secondary
+		$color = $this->getValueFor( 'color', 'primary' );
+		if ( $color === 'default' ) {
+			$color = 'secondary';
+		}
+		$class[] = $colorClass . $color;
 		if ( $size = $this->getValueFor( 'size' ) ) {
 			$class[] = "btn-" . $size;
 		}

--- a/src/Components/Button.php
+++ b/src/Components/Button.php
@@ -27,8 +27,8 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
-use \Title;
+use MediaWiki\Html\Html;
+use MediaWiki\Title\Title;
 
 /**
  * Class Button

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -93,7 +93,7 @@ class Card extends AbstractComponent {
 			'class' => $this->arrayToString( $innerClass, ' ' ),
 		];
 		if ( $this->isCollapsible() ) {
-			$innerAttributes['data-parent'] = $this->getDataParent();
+			$innerAttributes['data-bs-parent'] = $this->getDataParent();
 			$innerAttributes['aria-labelledby'] = $this->getId() . '_header';
 		}
 
@@ -250,11 +250,11 @@ class Card extends AbstractComponent {
 		if ( $type == 'header' ) {
 			if ( $this->isCollapsible() ) {
 				$newAttributes += [
-					'data-toggle'   => 'collapse',
-					'data-target'   => '#' . $this->getId(),
-					'aria-controls' => $this->getId(),
-					'aria-expanded' => $this->getValueFor( 'active' ) ? 'true' : 'false',
-					'id'            => $this->getId() . '_header'
+					'data-bs-toggle' => 'collapse',
+					'data-bs-target' => '#' . $this->getId(),
+					'aria-controls'  => $this->getId(),
+					'aria-expanded'  => $this->getValueFor( 'active' ) ? 'true' : 'false',
+					'id'             => $this->getId() . '_header'
 				];
 			}
 			$inside = Html::rawElement(

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -26,12 +26,12 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
-use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
+use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
-use \Html;
-use \MWException;
+use MediaWiki\Html\Html;
+use MWException;
 
 /**
  * Class Card

--- a/src/Components/Carousel.php
+++ b/src/Components/Carousel.php
@@ -60,10 +60,10 @@ class Carousel extends AbstractComponent {
 			Html::rawElement(
 				'div',
 				[
-					'class'     => $this->arrayToString( $class, ' ' ),
-					'style'     => $this->arrayToString( $style, ';' ),
-					'id'        => $this->getId(),
-					'data-ride' => 'carousel',
+					'class'        => $this->arrayToString( $class, ' ' ),
+					'style'        => $this->arrayToString( $style, ';' ),
+					'id'           => $this->getId(),
+					'data-bs-ride' => 'carousel',
 				],
 				$this->generateIndicators( count( $images ) )
 				. Html::rawElement(
@@ -87,19 +87,19 @@ class Carousel extends AbstractComponent {
 		return Html::rawElement(
 				'a',
 				[
-					'class'      => 'carousel-control-prev',
-					'href'       => '#' . $this->getId(),
-					'role'       => 'button',
-					'data-slide' => 'prev',
+					'class'         => 'carousel-control-prev',
+					'href'          => '#' . $this->getId(),
+					'role'          => 'button',
+					'data-bs-slide' => 'prev',
 				],
 				Html::rawElement( 'span', [ 'class' => 'carousel-control-prev-icon', 'aria-hidden' => 'true' ] )
 			) . Html::rawElement(
 				'a',
 				[
-					'class'      => 'carousel-control-next',
-					'href'       => '#' . $this->getId(),
-					'role'       => 'button',
-					'data-slide' => 'next',
+					'class'         => 'carousel-control-next',
+					'href'          => '#' . $this->getId(),
+					'role'          => 'button',
+					'data-bs-slide' => 'next',
 				],
 				Html::rawElement( 'span', [ 'class' => 'carousel-control-next-icon', 'aria-hidden' => 'true' ] )
 			);
@@ -188,9 +188,9 @@ class Carousel extends AbstractComponent {
 			$inner .= "\t" . Html::rawElement(
 					'li',
 					[
-						'data-target'   => '#' . $this->getId(),
-						'data-slide-to' => $i,
-						'class'         => $class,
+						'data-bs-target'   => '#' . $this->getId(),
+						'data-bs-slide-to' => $i,
+						'class'            => $class,
 					]
 				) . PHP_EOL;
 			$class = false;

--- a/src/Components/Carousel.php
+++ b/src/Components/Carousel.php
@@ -28,7 +28,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
 use MediaWiki\Extension\BootstrapComponents\ParserRequest;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Carousel

--- a/src/Components/Collapse.php
+++ b/src/Components/Collapse.php
@@ -74,7 +74,7 @@ class Collapse extends AbstractComponent {
 	 */
 	private function generateButton( ParserRequest $parserRequest ) {
 		$button = new Button( $this->getComponentLibrary(), $this->getParserOutputHelper(), $this->getNestingController() );
-		$button->injectRawAttributes( [ 'data-toggle' => 'collapse' ] );
+		$button->injectRawAttributes( [ 'data-bs-toggle' => 'collapse' ] );
 
 		$buttonAttributes = $parserRequest->getAttributes();
 		unset( $buttonAttributes['id'] );

--- a/src/Components/Collapse.php
+++ b/src/Components/Collapse.php
@@ -26,11 +26,11 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
-use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
+use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
 use MediaWiki\Extension\BootstrapComponents\ParserRequest;
-use \Html;
-use \MWException;
+use MediaWiki\Html\Html;
+use MWException;
 
 /**
  * Class Collapse

--- a/src/Components/Jumbotron.php
+++ b/src/Components/Jumbotron.php
@@ -44,9 +44,17 @@ class Jumbotron extends AbstractComponent {
 	 * @param string $input
 	 */
 	protected function placeMe( $input ) {
-		list ( $class, $style ) = $this->processCss( 'jumbotron', [] );
+		// Bootstrap 5 removed .jumbotron class
+		// Recreate it using Bootstrap 5 utility classes as per https://getbootstrap.com/docs/5.3/examples/jumbotron/
+		$class = [
+			'p-5',              // padding
+			'mb-4',             // margin-bottom
+			'bg-body-tertiary', // background color (Bootstrap 5.3)
+			'rounded-3'         // border-radius
+		];
+
+		list ( $class, $style ) = $this->processCss( $class, [] );
 		# @hack: the outer container is a workaround, to get all the necessary css if not inside a grid container
-		# @fixme: used inside mw content, the width calculation for smaller screens is broken (as of Bootstrap 1.2.3)
 		return Html::rawElement(
 			'div',
 			[

--- a/src/Components/Jumbotron.php
+++ b/src/Components/Jumbotron.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Jumbotron

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -102,13 +102,18 @@ class Modal extends AbstractComponent {
 	 * @return string
 	 */
 	private function generateButton( $text ) {
+		// Bootstrap 5 doesn't have btn-default, map to btn-secondary
+		$color = $this->getValueFor( 'color', 'secondary' );
+		if ( $color === 'default' ) {
+			$color = 'secondary';
+		}
 		return Html::rawElement(
 			'button',
 			[
-				'type'        => 'button',
-				'class'       => 'modal-trigger btn btn-' . $this->getValueFor( 'color', 'default' ),
-				'data-toggle' => 'modal',
-				'data-target' => '#' . $this->getId(),
+				'type'           => 'button',
+				'class'          => 'modal-trigger btn btn-' . $color,
+				'data-bs-toggle' => 'modal',
+				'data-bs-target' => '#' . $this->getId(),
 			],
 			$text
 		);

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -29,7 +29,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Components;
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
 use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
 use MediaWiki\Extension\BootstrapComponents\ModalBuilder;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Modal

--- a/src/Components/Popover.php
+++ b/src/Components/Popover.php
@@ -87,11 +87,11 @@ class Popover extends AbstractComponent {
 			$attributes = array_merge(
 				$attributes,
 				[
-					'data-toggle'    => 'popover',
-					'title'          => $heading,
-					'data-content'   => str_replace( "\n", " ", trim( $input ) ),
-					'data-placement' => $this->getValueFor( 'placement' ),
-					'data-trigger'   => $this->getValueFor( 'trigger' ),
+					'data-bs-toggle'    => 'popover',
+					'title'             => $heading,
+					'data-bs-content'   => str_replace( "\n", " ", trim( $input ) ),
+					'data-bs-placement' => $this->getValueFor( 'placement' ),
+					'data-bs-trigger'   => $this->getValueFor( 'trigger' ),
 				]
 			);
 			$tag = "button";
@@ -109,7 +109,12 @@ class Popover extends AbstractComponent {
 	 * @return string[]
 	 */
 	private function calculatePopoverClassAttribute() {
-		$class = [ 'btn', 'btn-' . $this->getValueFor( 'color', 'info' ) ];
+		// Bootstrap 5 doesn't have btn-default, map to btn-secondary
+		$color = $this->getValueFor( 'color', 'info' );
+		if ( $color === 'default' ) {
+			$color = 'secondary';
+		}
+		$class = [ 'btn', 'btn-' . $color ];
 		if ( $size = $this->getValueFor( 'size' ) ) {
 			$class[] = 'btn-' . $size;
 		}

--- a/src/Components/Popover.php
+++ b/src/Components/Popover.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Popover

--- a/src/Components/Tooltip.php
+++ b/src/Components/Tooltip.php
@@ -85,9 +85,9 @@ class Tooltip extends AbstractComponent {
 			$attributes = array_merge(
 				$attributes,
 				[
-					'data-placement' => $this->getValueFor( 'placement' ),
-					'data-toggle'    => 'tooltip',
-					'title'          => $tooltip,
+					'data-bs-placement' => $this->getValueFor( 'placement' ),
+					'data-bs-toggle'    => 'tooltip',
+					'title'             => $tooltip,
 				]
 			);
 			$tag = "span";

--- a/src/Components/Tooltip.php
+++ b/src/Components/Tooltip.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Tooltip

--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -26,7 +26,6 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Hooks;
 
-use MediaWiki\Extension\BootstrapComponents\BootstrapComponents;
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\ParserOutput;
@@ -34,26 +33,14 @@ use MediaWiki\Parser\ParserOutput;
 /**
  * Class OutputPageParserOutput
  *
- * Called after parse, before the HTML is added to the output.
- *
- * Method delegated to separate class to fix missing (deferred) content in
- * {@see \MediaWiki\Extension\BootstrapComponents\Tests\Integration\BootstrapComponentsJSONScriptTestCaseRunnerTest::assertParserOutputForCase}
+ * Called after parse, before the HTML is added to the output. Loads the Vector
+ * compat module when running under the Vector skin.
  *
  * @see   https://www.mediawiki.org/wiki/Manual:Hooks/OutputPageParserOutput
  *
  * @since 1.2
  */
 class OutputPageParserOutput {
-
-	/**
-	 * @var string
-	 */
-	const INJECTION_PREFIX = '<!-- injected by Extension:BootstrapComponents -->';
-
-	/**
-	 * @var string
-	 */
-	const INJECTION_SUFFIX = '<!-- /injected by Extension:BootstrapComponents -->';
 
 	/**
 	 * @var BootstrapComponentsService
@@ -89,34 +76,25 @@ class OutputPageParserOutput {
 	 * @return void
 	 */
 	public function process(): void	{
-		$deferredText = $this->getContentForLaterInjection( $this->getParserOutput() );
-		if ( !empty( $deferredText ) ) {
-			$this->getOutputPage()->addHTML( $deferredText );
-		}
+		// Bootstrap library JS (modals, popovers, tooltips, carousels, etc. all use
+		// `bootstrap.X.getOrCreateInstance(...)` under the BS5 vanilla-JS API).
+		$this->getOutputPage()->addModules( [ 'ext.bootstrap.scripts' ] );
+
+		// BC's per-component JS initialisers. Loaded here (not via addModules
+		// during ParserAfterParse) because addModules data set on the parse-time
+		// ParserOutput doesn't survive into the OutputPage lifecycle under
+		// MediaWiki 1.43+ — OutputPage is the persistent object, parse-time
+		// ParserOutput identity is not preserved.
+		$this->getOutputPage()->addModules( [
+			'ext.bootstrapComponents.modal.fix',
+			'ext.bootstrapComponents.popover.fix',
+			'ext.bootstrapComponents.tooltip.fix',
+			'ext.bootstrapComponents.carousel.fix',
+		] );
 
 		if ( $this->getBootstrapComponentsService()->vectorSkinInUse() ) {
 			$this->getOutputPage()->addModules( [ 'ext.bootstrapComponents.vector-fix' ] );
 		}
-	}
-
-	/**
-	 * Returns the raw html that is to be inserted at the end of the page.
-	 *
-	 * @param ParserOutput $parserOutput
-	 *
-	 * @return string
-	 */
-	protected function getContentForLaterInjection( ParserOutput $parserOutput ): string {
-		$deferredContent = $parserOutput
-			->getExtensionData(BootstrapComponents::EXTENSION_DATA_DEFERRED_CONTENT_KEY );
-
-		if ( empty( $deferredContent ) || !is_array( $deferredContent ) ) {
-			return '';
-		}
-
-		// clearing extension data for unit and integration tests to work
-		$parserOutput->setExtensionData( BootstrapComponents::EXTENSION_DATA_DEFERRED_CONTENT_KEY, null );
-		return self::INJECTION_PREFIX . implode( array_values( $deferredContent ) ) . self::INJECTION_SUFFIX;
 	}
 
 	protected function getBootstrapComponentsService(): BootstrapComponentsService {

--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -28,13 +28,8 @@ namespace MediaWiki\Extension\BootstrapComponents\Hooks;
 
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponents;
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
-/*
- * TODO switch to these, wehen we drop support for mw < 1.40
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\ParserOutput;
- */
-use \OutputPage;
-use \ParserOutput;
 
 /**
  * Class OutputPageParserOutput

--- a/src/Hooks/ParserFirstCallInit.php
+++ b/src/Hooks/ParserFirstCallInit.php
@@ -31,7 +31,7 @@ use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
-use Parser;
+use MediaWiki\Parser\Parser;
 use ReflectionClass;
 
 /**

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -225,6 +225,10 @@ class HooksHandler implements
 				continue;
 			}
 			foreach ( $this->getComponentLibrary()->getModulesFor( $activeComponent ) as $module ) {
+				// addModuleStyles for CSS only — the JS half of each component
+				// module is loaded centrally from OutputPageParserOutput::process()
+				// because addModules data does not survive the parse→OutputPage
+				// lifecycle under MediaWiki 1.43+.
 				$parser->getOutput()->addModuleStyles( [ $module ] );
 			}
 		}

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -14,9 +14,7 @@ use MediaWiki\Hook\ParserAfterParseHook;
 use MediaWiki\Hook\ParserFirstCallInitHook;
 use MediaWiki\Hook\SetupAfterCacheHook;
 use MediaWiki\MediaWikiServices;
-use Parser;
-// TODO switch to then when dropping support for mw < 1.40
-// use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\Parser;
 use SMW\Utils\File;
 use StripState;
 

--- a/src/ImageModal.php
+++ b/src/ImageModal.php
@@ -27,11 +27,11 @@
 namespace MediaWiki\Extension\BootstrapComponents;
 
 use File;
-use Html;
 use MediaTransformOutput;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use MWException;
-use Title;
 
 /**
  * Class ImageModal

--- a/src/ImageModalTrigger.php
+++ b/src/ImageModalTrigger.php
@@ -29,12 +29,11 @@ namespace MediaWiki\Extension\BootstrapComponents;
 use Config;
 use ConfigException;
 use Exception;
-use \Linker;
-use \Html;
-use \MediaWiki\MediaWikiServices;
-use MediaWiki\User\UserOptionsLookup;
-use \RequestContext;
-use \Title;
+use MediaWiki\Html\Html;
+use MediaWiki\Linker\Linker;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use RequestContext;
 
 /**
  * Class ImageModal

--- a/src/LuaLibrary.php
+++ b/src/LuaLibrary.php
@@ -26,12 +26,12 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
+use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
+use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LuaEngine;
 use MediaWiki\MediaWikiServices;
 use MWException;
 use ReflectionClass;
 use ReflectionException;
-use Scribunto_LuaEngine;
-use Scribunto_LuaLibraryBase;
 
 /**
  * Class LuaLibrary
@@ -40,7 +40,7 @@ use Scribunto_LuaLibraryBase;
  *
  * @since 1.1
  */
-class LuaLibrary extends Scribunto_LuaLibraryBase {
+class LuaLibrary extends LibraryBase {
 
 	/**
 	 * @var ApplicationFactory $applicationFactory;
@@ -55,9 +55,9 @@ class LuaLibrary extends Scribunto_LuaLibraryBase {
 	/**
 	 * LuaLibrary constructor.
 	 *
-	 * @param Scribunto_LuaEngine $engine
+	 * @param LuaEngine $engine
 	 */
-	public function __construct( Scribunto_LuaEngine $engine ) {
+	public function __construct( LuaEngine $engine ) {
 		parent::__construct( $engine );
 		$this->applicationFactory = ApplicationFactory::getInstance();
 		$this->bootstrapComponentService = MediaWikiServices::getInstance()->getService( 'BootstrapComponentsService' );

--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -162,14 +162,16 @@ class ModalBuilder {
 	/**
 	 * Parses the modal.
 	 *
+	 * Emits the trigger button followed by the modal container inline. Bootstrap 5
+	 * modals use `position: fixed` and locate themselves via `data-bs-target="#id"`,
+	 * so DOM placement is no longer significant the way it was for BS4 + Tidy. This
+	 * sidesteps the parser-output-extension-data lifecycle issues that broke the
+	 * old deferred-injection pattern under MediaWiki 1.43+ (oetterer/BootstrapComponents#68).
+	 *
 	 * @return string
 	 */
 	public function parse() {
-		$this->parserOutputHelper->injectLater(
-			$this->getId(),
-			$this->buildModal()
-		);
-		return $this->buildTrigger();
+		return $this->buildTrigger() . $this->buildModal();
 	}
 
 	/**

--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -26,8 +26,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use \Html;
-use MediaWiki\MediaWikiServices;
+use MediaWiki\Html\Html;
 
 /**
  * Class ModalBase

--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -123,9 +123,9 @@ class ModalBuilder {
 		return Html::rawElement(
 			'span',
 			[
-				'class'       => 'modal-trigger',
-				'data-toggle' => 'modal',
-				'data-target' => '#' . $id,
+				'class'          => 'modal-trigger',
+				'data-bs-toggle' => 'modal',
+				'data-bs-target' => '#' . $id,
 			],
 			$element
 		);
@@ -331,8 +331,8 @@ class ModalBuilder {
 	 */
 	protected function buildTrigger() {
 		$trigger = $this->getTrigger();
-		if ( preg_match( '/data-toggle[^"]+"modal/', $trigger )
-			&& preg_match( '/data-target[^"]+"#' . $this->getId() . '"/', $trigger )
+		if ( preg_match( '/data-bs-toggle[^"]+"modal/', $trigger )
+			&& preg_match( '/data-bs-target[^"]+"#' . $this->getId() . '"/', $trigger )
 			&& preg_match( '/class[^"]+"[^"]*modal-trigger' . '/', $trigger )
 		) {
 			return $trigger;
@@ -472,10 +472,10 @@ class ModalBuilder {
 				$footer . Html::rawElement(
 					'button',
 					[
-						'type'         => 'button',
-						'class'        => 'btn btn-default',
-						'data-dismiss' => 'modal',
-						'aria-label'   => $close,
+						'type'            => 'button',
+						'class'           => 'btn btn-secondary',
+						'data-bs-dismiss' => 'modal',
+						'aria-label'      => $close,
 					],
 					$close
 				)
@@ -502,16 +502,11 @@ class ModalBuilder {
 		$button = Html::rawElement(
 			'button',
 			[
-				'type'         => 'button',
-				'class'        => 'close',
-				'data-dismiss' => 'modal',
-				'aria-label'   => wfMessage( 'bootstrap-components-close-element' )->inContentLanguage()->text(),
-			],
-			Html::rawElement(
-				'span',
-				[ 'aria-hidden' => 'true' ],
-				'&times;'
-			)
+				'type'            => 'button',
+				'class'           => 'btn-close',
+				'data-bs-dismiss' => 'modal',
+				'aria-label'      => wfMessage( 'bootstrap-components-close-element' )->inContentLanguage()->text(),
+			]
 		);
 		return Html::rawElement(
 				'div',

--- a/src/ParserOutputHelper.php
+++ b/src/ParserOutputHelper.php
@@ -130,30 +130,6 @@ class ParserOutputHelper {
 	}
 
 	/**
-	 * Allows for html fragments for a given container id to be stored, so that it can be added to the page at a later time.
-	 *
-	 * @param string $id
-	 * @param string $rawHtml
-	 *
-	 * @return ParserOutputHelper $this (fluid)
-	 */
-	public function injectLater( $id, $rawHtml ) {
-		if ( empty( $this->getParser()->getOutput() ) ) {
-			# fix issues with PageForms file upload (issue #20)
-			return $this;
-		}
-		if ( !empty( $rawHtml ) ) {
-			$deferredContent = $this->getParser()->getOutput()->getExtensionData( BootstrapComponents::EXTENSION_DATA_DEFERRED_CONTENT_KEY );
-			if ( empty( $deferredContent ) ) {
-				$deferredContent = [];
-			}
-			$deferredContent[$id] = $rawHtml;
-			$this->getParser()->getOutput()->setExtensionData( BootstrapComponents::EXTENSION_DATA_DEFERRED_CONTENT_KEY, $deferredContent );
-		}
-		return $this;
-	}
-
-	/**
 	 * Formats a text as error text, so it can be added to the output.
 	 *
 	 * @param string $errorMessageName

--- a/src/ParserOutputHelper.php
+++ b/src/ParserOutputHelper.php
@@ -26,20 +26,11 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-/*
- * TODO: When dropping support for MW1.39, use these class imports:
 use MediaWiki\Html\Html;
 use MediaWiki\Message\Message;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
-*/
-
-use Html;
-use Message;
-use Parser;
-use ParserOutput;
-use Title;
 
 
 /**

--- a/src/ParserRequest.php
+++ b/src/ParserRequest.php
@@ -26,8 +26,8 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
+use MediaWiki\Parser\Parser;
 use MWException;
-use Parser;
 use PPFrame;
 
 /**

--- a/tests/PhpUnitEnvironment.php
+++ b/tests/PhpUnitEnvironment.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests;
 
-use \GitInfo;
+use GitInfo;
 
 /**
  * @private

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Integration;
 
-use \MediaWiki\MediaWikiServices;
+use MediaWiki\MediaWikiServices;
 use SMW\Tests\PHPUnitCompat;
 use SMW\Tests\Utils\UtilityFactory;
 

--- a/tests/phpunit/Integration/JSONScript/BootstrapComponentsJsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/BootstrapComponentsJsonTestCaseScriptRunnerTest.php
@@ -3,8 +3,8 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Integration;
 
 use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
-use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
 use MediaWiki\Extension\BootstrapComponents\HookRegistry;
+use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
 use SMW\DIWikiPage;
 use SMW\Tests\JSONScriptTestCaseRunner;
 use SMW\Tests\Utils\JSONScript\JsonTestCaseFileHandler;

--- a/tests/phpunit/Unit/CarouselGalleryTest.php
+++ b/tests/phpunit/Unit/CarouselGalleryTest.php
@@ -3,10 +3,9 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\CarouselGallery;
-use MediaWiki\Extension\BootstrapComponents\ParserRequest;
-use \MWException;
+use MediaWiki\Title\Title;
+use MWException;
 use PHPUnit\Framework\TestCase;
-use \Title;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\CarouselGallery

--- a/tests/phpunit/Unit/CarouselGalleryTest.php
+++ b/tests/phpunit/Unit/CarouselGalleryTest.php
@@ -82,17 +82,17 @@ class CarouselGalleryTest extends TestCase {
 					'fade'  => '',
 				],
 				[
-					0 => '<div class="carousel slide carousel-fade firefly" style="float:space" id="youcanttakethesky" data-ride="carousel">' . PHP_EOL
+					0 => '<div class="carousel slide carousel-fade firefly" style="float:space" id="youcanttakethesky" data-bs-ride="carousel">' . PHP_EOL
 						. '<ol class="carousel-indicators">' . PHP_EOL
-						. "\t". '<li data-target="#youcanttakethesky" data-slide-to="0" class="active"></li>' . PHP_EOL
-						. "\t". '<li data-target="#youcanttakethesky" data-slide-to="1"></li>' . PHP_EOL
-						. "\t". '<li data-target="#youcanttakethesky" data-slide-to="2"></li>' . PHP_EOL
+						. "\t". '<li data-bs-target="#youcanttakethesky" data-bs-slide-to="0" class="active"></li>' . PHP_EOL
+						. "\t". '<li data-bs-target="#youcanttakethesky" data-bs-slide-to="1"></li>' . PHP_EOL
+						. "\t". '<li data-bs-target="#youcanttakethesky" data-bs-slide-to="2"></li>' . PHP_EOL
 						. '</ol>' . PHP_EOL
 						. '<div class="carousel-inner">' . PHP_EOL
 						. "\t". '<div class="carousel-item active">[[File:Mal.jpg|Malcolm Reynolds|alt=(alt) Malcolm Reynolds|class=img-fluid]]</div>' . PHP_EOL
 						. "\t". '<div class="carousel-item">[[File:Wash.jpg|Hoban Washburne|link=/List_of_best_Pilots_in_the_Verse|class=img-fluid]]</div>' . PHP_EOL
 						. "\t". '<div class="carousel-item">[[File:MirandaSecretFiles.pdf|(c) by Hands of Blue|page=13|float=none|class=img-fluid]]</div>' . PHP_EOL
-						. '</div><a class="carousel-control-prev" href="#youcanttakethesky" role="button" data-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#youcanttakethesky" role="button" data-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
+						. '</div><a class="carousel-control-prev" href="#youcanttakethesky" role="button" data-bs-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#youcanttakethesky" role="button" data-bs-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
 					'isHTML' => true,
 					'noparse' => true,
 				],
@@ -104,15 +104,15 @@ class CarouselGalleryTest extends TestCase {
 				],
 				[],
 				[
-					0 => '<div class="carousel slide" id="bsc_carousel_0" data-ride="carousel">' . PHP_EOL
+					0 => '<div class="carousel slide" id="bsc_carousel_0" data-bs-ride="carousel">' . PHP_EOL
 						. '<ol class="carousel-indicators">' . PHP_EOL
-						. "\t". '<li data-target="#bsc_carousel_0" data-slide-to="0" class="active"></li>' . PHP_EOL
-						. "\t". '<li data-target="#bsc_carousel_0" data-slide-to="1"></li>' . PHP_EOL
+						. "\t". '<li data-bs-target="#bsc_carousel_0" data-bs-slide-to="0" class="active"></li>' . PHP_EOL
+						. "\t". '<li data-bs-target="#bsc_carousel_0" data-bs-slide-to="1"></li>' . PHP_EOL
 						. '</ol>' . PHP_EOL
 						. '<div class="carousel-inner">' . PHP_EOL
 						. "\t". '<div class="carousel-item active">[[File:Mal.jpg|Malcolm Reynolds|alt=(alt) Malcolm Reynolds|class=img-fluid]]</div>' . PHP_EOL
 						. "\t". '<div class="carousel-item">[[File:Wash.jpg|Hoban Washburne|link=/List_of_best_Pilots_in_the_Verse|class=img-fluid]]</div>' . PHP_EOL
-						. '</div><a class="carousel-control-prev" href="#bsc_carousel_0" role="button" data-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_0" role="button" data-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
+						. '</div><a class="carousel-control-prev" href="#bsc_carousel_0" role="button" data-bs-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_0" role="button" data-bs-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
 					'isHTML' => true,
 					'noparse' => true,
 				],

--- a/tests/phpunit/Unit/Components/AccordionTest.php
+++ b/tests/phpunit/Unit/Components/AccordionTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Accordion as Accordion;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Accordion

--- a/tests/phpunit/Unit/Components/AlertTest.php
+++ b/tests/phpunit/Unit/Components/AlertTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Alert;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Alert

--- a/tests/phpunit/Unit/Components/AlertTest.php
+++ b/tests/phpunit/Unit/Components/AlertTest.php
@@ -91,17 +91,17 @@ class AlertTest extends ComponentsTestBase {
 			'dismiss_arbitrary'       => [
 				$this->input,
 				[ 'dismissible' => 'bla' ],
-				'<div class="alert alert-primary alert-dismissible" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>',
+				'<div class="alert alert-primary alert-dismissible" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>',
 			],
 			'dismiss'               => [
 				$this->input,
 				[ 'dismissible' => true ],
-				'<div class="alert alert-primary alert-dismissible" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>',
+				'<div class="alert alert-primary alert-dismissible" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>',
 			],
 			'fading'                => [
 				$this->input,
 				[ 'dismissible' => 'fade', 'color' => 'warning' ],
-				'<div class="alert alert-warning alert-dismissible fade show" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>',
+				'<div class="alert alert-warning alert-dismissible fade show" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>',
 			],
 			'manual id, no dismiss' => [
 				$this->input,

--- a/tests/phpunit/Unit/Components/BadgeTest.php
+++ b/tests/phpunit/Unit/Components/BadgeTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Badge;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Badge

--- a/tests/phpunit/Unit/Components/BadgeTest.php
+++ b/tests/phpunit/Unit/Components/BadgeTest.php
@@ -69,7 +69,7 @@ class BadgeTest extends ComponentsTestBase {
 			'simple'          => [
 				$this->input,
 				[],
-				'<span class="badge badge-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
+				'<span class="badge text-bg-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
 			],
 			'empty'           => [
 				'',
@@ -79,22 +79,22 @@ class BadgeTest extends ComponentsTestBase {
 			'manual id'       => [
 				$this->input,
 				[ 'id' => 'book' ],
-				'<span class="badge badge-primary" id="book">' . $this->input . '</span>',
+				'<span class="badge text-bg-primary" id="book">' . $this->input . '</span>',
 			],
 			'style and class' => [
 				$this->input,
 				[ 'class' => 'dummy nice', 'style' => 'float:right;background-color:#80266e' ],
-				'<span class="badge badge-primary dummy nice" style="float:right;background-color:#80266e" id="bsc_badge_NULL">' . $this->input . '</span>',
+				'<span class="badge text-bg-primary dummy nice" style="float:right;background-color:#80266e" id="bsc_badge_NULL">' . $this->input . '</span>',
 			],
 			'pill'       => [
 				$this->input,
 				[ 'pill' => 'true' ],
-				'<span class="badge rounded-pill badge-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
+				'<span class="badge rounded-pill text-bg-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
 			],
 			'no pill'       => [
 				$this->input,
 				[ 'pill' => 0 ],
-				'<span class="badge badge-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
+				'<span class="badge text-bg-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/BadgeTest.php
+++ b/tests/phpunit/Unit/Components/BadgeTest.php
@@ -89,7 +89,7 @@ class BadgeTest extends ComponentsTestBase {
 			'pill'       => [
 				$this->input,
 				[ 'pill' => 'true' ],
-				'<span class="badge badge-pill badge-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
+				'<span class="badge rounded-pill badge-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
 			],
 			'no pill'       => [
 				$this->input,

--- a/tests/phpunit/Unit/Components/ButtonTest.php
+++ b/tests/phpunit/Unit/Components/ButtonTest.php
@@ -85,7 +85,7 @@ class ButtonTest extends ComponentsTestBase {
 		);
 
 		$instance->injectRawAttributes(
-			[ 'data-toggle' => 'foo', 'data-target' => '#bar' ]
+			[ 'data-bs-toggle' => 'foo', 'data-bs-target' => '#bar' ]
 		);
 
 		$generatedOutput = $instance->parseComponent( $parserRequest );
@@ -98,14 +98,14 @@ class ButtonTest extends ComponentsTestBase {
 			$this->assertRegExp(
 				'~^<a class="btn btn-primary btn-md manual" role="button" id="bsc_button_NULL" href=".*/'
 				. str_replace( ' ', '_', $this->input )
-				. '" data-toggle="foo" data-target="#bar">' . $this->input . '</a>$~',
+				. '" data-bs-toggle="foo" data-bs-target="#bar">' . $this->input . '</a>$~',
 				$generatedOutput
 			);
 		} else {
 			$this->assertMatchesRegularExpression(
 				'~^<a class="btn btn-primary btn-md manual" role="button" id="bsc_button_NULL" href=".*/'
 				. str_replace( ' ', '_', $this->input )
-				. '" data-toggle="foo" data-target="#bar">' . $this->input . '</a>$~',
+				. '" data-bs-toggle="foo" data-bs-target="#bar">' . $this->input . '</a>$~',
 				$generatedOutput
 			);
 		}

--- a/tests/phpunit/Unit/Components/ButtonTest.php
+++ b/tests/phpunit/Unit/Components/ButtonTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Button;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Button

--- a/tests/phpunit/Unit/Components/CardTest.php
+++ b/tests/phpunit/Unit/Components/CardTest.php
@@ -148,7 +148,7 @@ class CardTest extends ComponentsTestBase {
 					'footer-style'=> 'padding:5px',
 				],
 				'<div class="card border-info dummy nice" style="float:right;background-color:green">'
-				. '<div class="card-header" style="padding:5px" data-toggle="collapse" data-target="#badgers_bowler" aria-controls="badgers_bowler" aria-expanded="true" id="badgers_bowler_header">'
+				. '<div class="card-header" style="padding:5px" data-bs-toggle="collapse" data-bs-target="#badgers_bowler" aria-controls="badgers_bowler" aria-expanded="true" id="badgers_bowler_header">'
 				. '<h4 class="card-title" style="margin-top:0;padding-top:0;">HEADING TEXT</h4></div>[[File:Serenity.png]]'
 				. '<div id="badgers_bowler" class="card-collapse collapse fade show" aria-labelledby="badgers_bowler_header"><div class="card-body text-info" style="padding:5px">'
 				. $this->input . '</div>[[File:Serenity.png|class=card-img-bottom]]<div class="card-footer" style="padding:5px">FOOTER TEXT</div></div></div>',
@@ -179,12 +179,12 @@ class CardTest extends ComponentsTestBase {
 			'simple'            => [
 				$this->input,
 				[],
-				'<div class="card"><div class="card-header" data-toggle="collapse" data-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">bsc_card_NULL</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body">' . $this->input . '</div></div></div>',
+				'<div class="card"><div class="card-header" data-bs-toggle="collapse" data-bs-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">bsc_card_NULL</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-bs-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body">' . $this->input . '</div></div></div>',
 			],
 			'text missing'      => [
 				'',
 				[ 'header' => 'watch this', 'footer' => 'watch what?', 'collapsible' => 'false', ],
-				'<div class="card"><div class="card-header" data-toggle="collapse" data-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">watch this</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body"></div><div class="card-footer">watch what?</div></div></div>',
+				'<div class="card"><div class="card-header" data-bs-toggle="collapse" data-bs-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">watch this</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-bs-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body"></div><div class="card-footer">watch what?</div></div></div>',
 			],
 			'all attributes'    => [
 				$this->input,
@@ -198,12 +198,12 @@ class CardTest extends ComponentsTestBase {
 					'heading'     => 'HEADING TEXT',
 					'footer'      => 'FOOTER TEXT',
 				],
-				'<div class="card border-info dummy nice" style="float:right;background-color:green"><div class="card-header" data-toggle="collapse" data-target="#badgers_bowler" aria-controls="badgers_bowler" aria-expanded="true" id="badgers_bowler_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">HEADING TEXT</h4></div><div id="badgers_bowler" class="card-collapse collapse fade show" data-parent="#accordion0" aria-labelledby="badgers_bowler_header"><div class="card-body text-info">' . $this->input . '</div><div class="card-footer">FOOTER TEXT</div></div></div>',
+				'<div class="card border-info dummy nice" style="float:right;background-color:green"><div class="card-header" data-bs-toggle="collapse" data-bs-target="#badgers_bowler" aria-controls="badgers_bowler" aria-expanded="true" id="badgers_bowler_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">HEADING TEXT</h4></div><div id="badgers_bowler" class="card-collapse collapse fade show" data-bs-parent="#accordion0" aria-labelledby="badgers_bowler_header"><div class="card-body text-info">' . $this->input . '</div><div class="card-footer">FOOTER TEXT</div></div></div>',
 			],
 			'collapsible false' => [
 				$this->input,
 				[ 'collapsible' => 'false', ],
-				'<div class="card"><div class="card-header" data-toggle="collapse" data-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">bsc_card_NULL</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body">' . $this->input . '</div></div></div>',
+				'<div class="card"><div class="card-header" data-bs-toggle="collapse" data-bs-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">bsc_card_NULL</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-bs-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body">' . $this->input . '</div></div></div>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/CardTest.php
+++ b/tests/phpunit/Unit/Components/CardTest.php
@@ -6,7 +6,7 @@ use MediaWiki\Extension\BootstrapComponents\Components\Accordion;
 use MediaWiki\Extension\BootstrapComponents\Components\Card;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Card

--- a/tests/phpunit/Unit/Components/CarouselTest.php
+++ b/tests/phpunit/Unit/Components/CarouselTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Carousel;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Carousel

--- a/tests/phpunit/Unit/Components/CarouselTest.php
+++ b/tests/phpunit/Unit/Components/CarouselTest.php
@@ -79,17 +79,17 @@ class CarouselTest extends ComponentsTestBase {
 			'simple'                     => [
 				'[[File:Mal.jpg|Malcolm Reynolds_0]]',
 				[ '[[File:Mal.jpg|Malcolm Reynolds]]' => true, '[[File:Wash.jpg|link' => '|Hoban Washburne]]' ],
-				'<div class="carousel slide" id="bsc_carousel_NULL" data-ride="carousel">
+				'<div class="carousel slide" id="bsc_carousel_NULL" data-bs-ride="carousel">
 <ol class="carousel-indicators">
-	<li data-target="#bsc_carousel_NULL" data-slide-to="0" class="active"></li>
-	<li data-target="#bsc_carousel_NULL" data-slide-to="1"></li>
-	<li data-target="#bsc_carousel_NULL" data-slide-to="2"></li>
+	<li data-bs-target="#bsc_carousel_NULL" data-bs-slide-to="0" class="active"></li>
+	<li data-bs-target="#bsc_carousel_NULL" data-bs-slide-to="1"></li>
+	<li data-bs-target="#bsc_carousel_NULL" data-bs-slide-to="2"></li>
 </ol>
 <div class="carousel-inner">
 	<div class="carousel-item active">[[File:Mal.jpg|Malcolm Reynolds_0]]</div>
 	<div class="carousel-item">[[File:Mal.jpg|Malcolm Reynolds]]</div>
 	<div class="carousel-item">[[File:Wash.jpg|link=|Hoban Washburne]]</div>
-</div><a class="carousel-control-prev" href="#bsc_carousel_NULL" role="button" data-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_NULL" role="button" data-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
+</div><a class="carousel-control-prev" href="#bsc_carousel_NULL" role="button" data-bs-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_NULL" role="button" data-bs-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
 			],
 			'images missing'             => [
 				$this->input,
@@ -105,15 +105,15 @@ class CarouselTest extends ComponentsTestBase {
 					'fade'                              => true,
 					'style'                             => 'float:none;background-color:black',
 				],
-				'<div class="carousel slide carousel-fade crew" style="float:none;background-color:black" id="bsc_carousel_NULL" data-ride="carousel">
+				'<div class="carousel slide carousel-fade crew" style="float:none;background-color:black" id="bsc_carousel_NULL" data-bs-ride="carousel">
 <ol class="carousel-indicators">
-	<li data-target="#bsc_carousel_NULL" data-slide-to="0" class="active"></li>
-	<li data-target="#bsc_carousel_NULL" data-slide-to="1"></li>
+	<li data-bs-target="#bsc_carousel_NULL" data-bs-slide-to="0" class="active"></li>
+	<li data-bs-target="#bsc_carousel_NULL" data-bs-slide-to="1"></li>
 </ol>
 <div class="carousel-inner">
 	<div class="carousel-item active">[[File:Mal.jpg|Malcolm Reynolds]]</div>
 	<div class="carousel-item">[[File:Wash.jpg|link=|Hoban Washburne]]</div>
-</div><a class="carousel-control-prev" href="#bsc_carousel_NULL" role="button" data-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_NULL" role="button" data-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
+</div><a class="carousel-control-prev" href="#bsc_carousel_NULL" role="button" data-bs-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_NULL" role="button" data-bs-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/CollapseTest.php
+++ b/tests/phpunit/Unit/Components/CollapseTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Collapse;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Collapse

--- a/tests/phpunit/Unit/Components/CollapseTest.php
+++ b/tests/phpunit/Unit/Components/CollapseTest.php
@@ -69,27 +69,27 @@ class CollapseTest extends ComponentsTestBase {
 			'simple'          => [
 				$this->input,
 				[],
-				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
+				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-bs-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
 			],
 			'color_unknown'   => [
 				$this->input,
 				[ 'color' => 'unknown' ],
-				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
+				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-bs-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
 			],
 			'button text'     => [
 				$this->input,
 				[ 'text' => 'BUTTON' ],
-				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-toggle="collapse">BUTTON</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
+				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-bs-toggle="collapse">BUTTON</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
 			],
 			'manual id'       => [
 				$this->input,
 				[ 'color' => 'success', 'id' => 'alliance' ],
-				'<a class="btn btn-success" role="button" id="bsc_button_NULL" href="#alliance" data-toggle="collapse">#alliance</a><div class="collapse" id="alliance">' . $this->input . '</div>',
+				'<a class="btn btn-success" role="button" id="bsc_button_NULL" href="#alliance" data-bs-toggle="collapse">#alliance</a><div class="collapse" id="alliance">' . $this->input . '</div>',
 			],
 			'style and class' => [
 				$this->input,
 				[ 'class' => 'dummy nice', 'style' => 'float:right;background-color:green' ],
-				'<a class="btn btn-primary dummy nice" style="float:right;background-color:green" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse dummy nice" style="float:right;background-color:green" id="bsc_collapse_NULL">' . $this->input . '</div>',
+				'<a class="btn btn-primary dummy nice" style="float:right;background-color:green" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-bs-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse dummy nice" style="float:right;background-color:green" id="bsc_collapse_NULL">' . $this->input . '</div>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/JumbotronTest.php
+++ b/tests/phpunit/Unit/Components/JumbotronTest.php
@@ -69,17 +69,17 @@ class JumbotronTest extends ComponentsTestBase {
 			'simple'          => [
 				$this->input,
 				[],
-				'<div class="container"><div class="jumbotron" id="bsc_jumbotron_NULL">' . $this->input . '</div></div>',
+				'<div class="container"><div class="p-5 mb-4 bg-body-tertiary rounded-3" id="bsc_jumbotron_NULL">' . $this->input . '</div></div>',
 			],
 			'manual id'       => [
 				$this->input,
 				[ 'id' => 'hms_dortmunder' ],
-				'<div class="container"><div class="jumbotron" id="hms_dortmunder">' . $this->input . '</div></div>',
+				'<div class="container"><div class="p-5 mb-4 bg-body-tertiary rounded-3" id="hms_dortmunder">' . $this->input . '</div></div>',
 			],
 			'style and class' => [
 				$this->input,
 				[ 'class' => 'dummy nice', 'style' => 'float:right;background-color:green' ],
-				'<div class="container"><div class="jumbotron dummy nice" style="float:right;background-color:green" id="bsc_jumbotron_NULL">' . $this->input . '</div></div>',
+				'<div class="container"><div class="p-5 mb-4 bg-body-tertiary rounded-3 dummy nice" style="float:right;background-color:green" id="bsc_jumbotron_NULL">' . $this->input . '</div></div>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/JumbotronTest.php
+++ b/tests/phpunit/Unit/Components/JumbotronTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Jumbotron;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Jumbotron

--- a/tests/phpunit/Unit/Components/ModalTest.php
+++ b/tests/phpunit/Unit/Components/ModalTest.php
@@ -49,15 +49,9 @@ class ModalTest extends ComponentsTestBase {
 	 */
 	public function testCanRender( $input, $arguments, $expectedTriggerOutput, $expectedModalOutput ) {
 
-		$modalInjection = '';
 		$parserOutputHelper = $this->getMockBuilder( 'MediaWiki\\Extension\\BootstrapComponents\\ParserOutputHelper' )
 			->disableOriginalConstructor()
 			->getMock();
-		$parserOutputHelper->expects( $this->any() )
-			->method( 'injectLater' )
-			->will( $this->returnCallback( function( $id, $text ) use ( &$modalInjection ) {
-				$modalInjection .= $text;
-			} ) );
 		$parserOutputHelper->expects( $this->any() )
 			->method( 'renderErrorMessage' )
 			->will( $this->returnArgument( 0 ) );
@@ -74,11 +68,11 @@ class ModalTest extends ComponentsTestBase {
 		/** @noinspection PhpParamsInspection */
 		$generatedOutput = $instance->parseComponent( $parserRequest );
 
-		$this->assertEquals( $expectedTriggerOutput, $generatedOutput );
-		$this->assertEquals(
-			$expectedModalOutput,
-			$modalInjection
-		);
+		// Inline-emission refactor: the parser hook output is now the trigger
+		// HTML followed by the modal container HTML, concatenated. Previously
+		// they were returned separately (trigger via the parser return value,
+		// modal via parserOutputHelper->injectLater()). Asserts the union here.
+		$this->assertEquals( $expectedTriggerOutput . $expectedModalOutput, $generatedOutput );
 	}
 
 	/**

--- a/tests/phpunit/Unit/Components/ModalTest.php
+++ b/tests/phpunit/Unit/Components/ModalTest.php
@@ -89,9 +89,9 @@ class ModalTest extends ComponentsTestBase {
 			'simple'              => [
 				$this->input,
 				[ 'text' => 'BUTTON' ],
-				'<button type="button" class="modal-trigger btn btn-default" data-toggle="modal" data-target="#bsc_modal_NULL">BUTTON</button>',
-				'<div class="modal fade" role="dialog" id="bsc_modal_NULL" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'<button type="button" class="modal-trigger btn btn-secondary" data-bs-toggle="modal" data-bs-target="#bsc_modal_NULL">BUTTON</button>',
+				'<div class="modal fade" role="dialog" id="bsc_modal_NULL" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'text missing'        => [
 				$this->input,
@@ -105,9 +105,9 @@ class ModalTest extends ComponentsTestBase {
 					'text' => 'before<a href="/File:Serenity.png" class="image"><img alt="Serenity" src="/images/a/aa/Serenity.png" width="160" height="42"></a>after',
 					'size' => 'none',
 				],
-				'<span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_NULL">before<img alt="Serenity" src="/images/a/aa/Serenity.png" width="160" height="42">after</span>',
-				'<div class="modal fade" role="dialog" id="bsc_modal_NULL" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_NULL">before<img alt="Serenity" src="/images/a/aa/Serenity.png" width="160" height="42">after</span>',
+				'<div class="modal fade" role="dialog" id="bsc_modal_NULL" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'all attributes'      => [
 				$this->input,
@@ -116,9 +116,9 @@ class ModalTest extends ComponentsTestBase {
 					'id'      => 'firefly0', 'size' => 'lg', 'class' => 'shiny', 'style' => 'float:right;background-color:black',
 					'heading' => 'You can\'t take the sky from me!',
 				],
-				'<span class="modal-trigger" data-toggle="modal" data-target="#firefly0"><img alt="Serenity" src="/images/a/aa/Serenity.png" width="160" height="42"></span>',
-				'<div class="modal fade shiny" style="float:right;background-color:black" role="dialog" id="firefly0" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><span class="modal-title">You can\'t take the sky from me!</span><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#firefly0"><img alt="Serenity" src="/images/a/aa/Serenity.png" width="160" height="42"></span>',
+				'<div class="modal fade shiny" style="float:right;background-color:black" role="dialog" id="firefly0" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><span class="modal-title">You can\'t take the sky from me!</span><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/ModalTest.php
+++ b/tests/phpunit/Unit/Components/ModalTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Modal;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Modal

--- a/tests/phpunit/Unit/Components/PopoverTest.php
+++ b/tests/phpunit/Unit/Components/PopoverTest.php
@@ -69,7 +69,7 @@ class PopoverTest extends ComponentsTestBase {
 			'simple'          => [
 				$this->input,
 				[ 'heading' => 'heading', 'text' => 'BUTTON' ],
-				'<button class="btn btn-info" id="bsc_popover_NULL" data-toggle="popover" title="heading" data-content="' . $this->input . '" type="submit">BUTTON</button>',
+				'<button class="btn btn-info" id="bsc_popover_NULL" data-bs-toggle="popover" title="heading" data-bs-content="' . $this->input . '" type="submit">BUTTON</button>',
 			],
 			'heading empty' => [
 				$this->input,
@@ -87,7 +87,7 @@ class PopoverTest extends ComponentsTestBase {
 					'heading'   => 'heading', 'text' => 'BUTTON', 'class' => 'dummy nice', 'style' => 'float:right;background-color:green',
 					'placement' => 'right', 'trigger' => 'hover', 'id' => 'cudgel', 'size' => 'sm'
 				],
-				'<button class="btn btn-info btn-sm dummy nice" style="float:right;background-color:green" id="cudgel" data-toggle="popover" title="heading" data-content="' . $this->input . '" data-placement="right" data-trigger="hover" type="submit">BUTTON</button>',
+				'<button class="btn btn-info btn-sm dummy nice" style="float:right;background-color:green" id="cudgel" data-bs-toggle="popover" title="heading" data-bs-content="' . $this->input . '" data-bs-placement="right" data-bs-trigger="hover" type="submit">BUTTON</button>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/PopoverTest.php
+++ b/tests/phpunit/Unit/Components/PopoverTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Popover;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Popover

--- a/tests/phpunit/Unit/Components/TooltipTest.php
+++ b/tests/phpunit/Unit/Components/TooltipTest.php
@@ -74,7 +74,7 @@ class TooltipTest extends ComponentsTestBase {
 			'simple'              => [
 				$this->input,
 				[ 'text' => 'simple' ],
-				'<span class="bootstrap-tooltip" id="bsc_tooltip_NULL" data-toggle="tooltip" title="simple">' . $this->input . '</span>',
+				'<span class="bootstrap-tooltip" id="bsc_tooltip_NULL" data-bs-toggle="tooltip" title="simple">' . $this->input . '</span>',
 			],
 			'empty'               => [
 				'',
@@ -89,7 +89,7 @@ class TooltipTest extends ComponentsTestBase {
 			'id, style and class' => [
 				$this->input,
 				[ 'text' => 'simple', 'class' => 'dummy nice', 'style' => 'float:right;background-color:#80266e', 'id' => 'vera' ],
-				'<span class="bootstrap-tooltip dummy nice" style="float:right;background-color:#80266e" id="vera" data-toggle="tooltip" title="simple">' . $this->input . '</span>',
+				'<span class="bootstrap-tooltip dummy nice" style="float:right;background-color:#80266e" id="vera" data-bs-toggle="tooltip" title="simple">' . $this->input . '</span>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/TooltipTest.php
+++ b/tests/phpunit/Unit/Components/TooltipTest.php
@@ -5,7 +5,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 use MediaWiki\Extension\BootstrapComponents\Components\Tooltip;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Tooltip

--- a/tests/phpunit/Unit/ComponentsTestBase.php
+++ b/tests/phpunit/Unit/ComponentsTestBase.php
@@ -6,8 +6,8 @@ use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
 use MediaWiki\Extension\BootstrapComponents\ParserRequest;
+use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
-use Parser;
 use PPFrame;
 
 /**

--- a/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
@@ -39,40 +39,71 @@ class OutputPageParserOutputTest extends TestCase {
 		);
 	}
 
-	public function testHookOutputPageParserOutput() {
-		$content = 'CONTENT';
+	public function testHookOutputPageParserOutputLoadsModules() {
+		// Collect every addModules() call so we can assert the union of module sets
+		$loadedModules = [];
 
 		$outputPage = $this->createMock( OutputPage::class );
-		$outputPage->expects( $this->once() )
-			->method( 'addHTML' )
-			->will( $this->returnCallback( function( $injection ) use ( &$content ) {
-				$content .= $injection;
-			} ) );
-		$outputPage->expects( $this->once() )
+		$outputPage->expects( $this->atLeastOnce() )
 			->method( 'addModules' )
-			->with(
-				$this->equalTo( [ 'ext.bootstrapComponents.vector-fix' ] )
-			);
+			->will( $this->returnCallback( function( $modules ) use ( &$loadedModules ) {
+				$loadedModules = array_merge( $loadedModules, (array)$modules );
+			} ) );
 
-		$observerParserOutput = $this->createMock( ParserOutput::class );
-		$observerParserOutput->expects( $this->exactly( 1 ) )
-			->method( 'getExtensionData' )
-			->with(
-				$this->stringContains( 'bsc_deferredContent' )
-			)
-			->willReturn( [ 'test' ] );
+		// addHTML should NOT be called any more — the deferred-content injection
+		// pattern was replaced by inline emission in ModalBuilder::parse().
+		$outputPage->expects( $this->never() )->method( 'addHTML' );
 
 		$bootstrapService = $this->createMock( BootstrapComponentsService::class );
 		$bootstrapService->expects( $this->once() )
 			->method( 'vectorSkinInUse' )
 			->willReturn( true );
 
-		$instance = new OutputPageParserOutput( $outputPage, $observerParserOutput, $bootstrapService );
+		$instance = new OutputPageParserOutput(
+			$outputPage,
+			$this->createMock( ParserOutput::class ),
+			$bootstrapService
+		);
 		$instance->process();
 
-		$this->assertEquals(
-			'CONTENT<!-- injected by Extension:BootstrapComponents -->test<!-- /injected by Extension:BootstrapComponents -->',
-			$content
+		// Bootstrap library JS, BC's per-component JS init modules, and the
+		// Vector-fix module (because vectorSkinInUse returns true above) should
+		// all reach OutputPage::addModules().
+		$expected = [
+			'ext.bootstrap.scripts',
+			'ext.bootstrapComponents.modal.fix',
+			'ext.bootstrapComponents.popover.fix',
+			'ext.bootstrapComponents.tooltip.fix',
+			'ext.bootstrapComponents.carousel.fix',
+			'ext.bootstrapComponents.vector-fix',
+		];
+		sort( $loadedModules );
+		sort( $expected );
+		$this->assertEquals( $expected, $loadedModules );
+	}
+
+	public function testVectorFixSkippedWhenNotVectorSkin() {
+		$loadedModules = [];
+
+		$outputPage = $this->createMock( OutputPage::class );
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'addModules' )
+			->will( $this->returnCallback( function( $modules ) use ( &$loadedModules ) {
+				$loadedModules = array_merge( $loadedModules, (array)$modules );
+			} ) );
+
+		$bootstrapService = $this->createMock( BootstrapComponentsService::class );
+		$bootstrapService->expects( $this->once() )
+			->method( 'vectorSkinInUse' )
+			->willReturn( false );
+
+		$instance = new OutputPageParserOutput(
+			$outputPage,
+			$this->createMock( ParserOutput::class ),
+			$bootstrapService
 		);
+		$instance->process();
+
+		$this->assertNotContains( 'ext.bootstrapComponents.vector-fix', $loadedModules );
 	}
 }

--- a/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
@@ -4,8 +4,8 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Hooks;
 
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
-use OutputPage;
-use ParserOutput;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Parser\ParserOutput;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/phpunit/Unit/Hooks/ParserFirstCallInitTest.php
+++ b/tests/phpunit/Unit/Hooks/ParserFirstCallInitTest.php
@@ -2,9 +2,9 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Hooks;
 
-use MediaWiki\Extension\BootstrapComponents\Hooks\ParserFirstCallInit as ParserFirstCallInit;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
-use \Parser;
+use MediaWiki\Extension\BootstrapComponents\Hooks\ParserFirstCallInit as ParserFirstCallInit;
+use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/phpunit/Unit/ImageModalTest.php
+++ b/tests/phpunit/Unit/ImageModalTest.php
@@ -309,9 +309,9 @@ class ImageModalTest extends TestCase {
 			'no params' => [
 				[],
 				[],
-				'~<span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'frame params w/o thumbnail' => [
 				[
@@ -323,9 +323,9 @@ class ImageModalTest extends TestCase {
 					'valign'  => 'text-top',
 				],
 				[],
-				'~<div class="floatleft"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><img src=TEST_OUTPUT alt="test_alt" title="test_title" class="test_class"></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT alt="test_alt" title="test_title" class="test_class img-fluid"> <div class="modal-caption">test_caption:not next line, still not next line, .' . PHP_EOL . PHP_EOL . 'next line</div></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="floatleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><img src=TEST_OUTPUT alt="test_alt" title="test_title" class="test_class"></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT alt="test_alt" title="test_title" class="test_class img-fluid"> <div class="modal-caption">test_caption:not next line, still not next line, .' . PHP_EOL . PHP_EOL . 'next line</div></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'manual width, frameless' => [
 				[
@@ -336,9 +336,9 @@ class ImageModalTest extends TestCase {
 					'width' => 200,
 					'page'  => 7,
 				],
-				'~<div class="floatleft"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png?page=7">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="floatleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png?page=7">Visit Source</a><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'thumbnail, manual width' => [
 				[
@@ -349,9 +349,9 @@ class ImageModalTest extends TestCase {
 					'width' => 200,
 					'page'  => 7,
 				],
-				'~<div class="thumb tmiddle"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:642px;"><img src=TEST_OUTPUT class="thumbimage">  <div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge"></a></div></div></div></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div><div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div>'
-				. '<div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png?page=7">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="thumb tmiddle"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><div class="thumbinner" style="width:642px;"><img src=TEST_OUTPUT class="thumbimage">  <div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge"></a></div></div></div></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div><div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div>'
+				. '<div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png?page=7">Visit Source</a><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'manual thumbnail, NOT centered' => [
 				[
@@ -360,9 +360,9 @@ class ImageModalTest extends TestCase {
 					'framed'      => false,
 				],
 				[],
-				'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;">(<span>)?<img alt="" src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage" />(</span>)?  <div class="thumbcaption"></div></div></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div><div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div>'
-				. '<div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="thumb tnone"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;"><span><img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?></span>  <div class="thumbcaption"></div></div></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div><div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div>'
+				. '<div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'framed' => [
 				[
@@ -370,9 +370,9 @@ class ImageModalTest extends TestCase {
 					'framed' => false,
 				],
 				[],
-				'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:642px;"><img src=TEST_OUTPUT class="thumbimage">  <div class="thumbcaption"></div></div></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="thumb tnone"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><div class="thumbinner" style="width:642px;"><img src=TEST_OUTPUT class="thumbimage">  <div class="thumbcaption"></div></div></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'centered' => [
 				[
@@ -381,9 +381,9 @@ class ImageModalTest extends TestCase {
 				[
 					'width' => 200,
 				],
-				'~<div class="center"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="center"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'manual thumbnail, upright' => [
 				[
@@ -392,9 +392,9 @@ class ImageModalTest extends TestCase {
 					'manualthumb' => 'Shuttle.png',
 				],
 				[],
-				'~<div class="thumb tleft"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;">(<span>)?<img alt="" src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage" />(</span>)?  <div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge"></a></div></div></div></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="thumb tleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;"><span><img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?></span>  <div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge"></a></div></div></div></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 		];
 	}

--- a/tests/phpunit/Unit/ImageModalTest.php
+++ b/tests/phpunit/Unit/ImageModalTest.php
@@ -2,17 +2,17 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
+use ConfigException;
 use File;
 use LocalFile;
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\ImageModal;
-use \ConfigException;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
-use \MediaWiki\MediaWikiServices;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use ThumbnailImage;
-use Title;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\ImageModal

--- a/tests/phpunit/Unit/ImageModalTest.php
+++ b/tests/phpunit/Unit/ImageModalTest.php
@@ -254,13 +254,7 @@ class ImageModalTest extends TestCase {
 				}
 			) );
 
-		$modalInjection = '';
 		$parserOutputHelper = $this->createMock( ParserOutputHelper::class );
-		$parserOutputHelper->expects( $this->any() )
-			->method( 'injectLater' )
-			->will( $this->returnCallback( function( $id, $text ) use ( &$modalInjection ) {
-				$modalInjection .= $text;
-			} ) );
 
 		$instance = $this->createImageModalWithMocks( null, $title, $file, $nestingController, null, $parserOutputHelper );
 		$time = false;
@@ -283,9 +277,12 @@ class ImageModalTest extends TestCase {
 				. '--  ' . ($resultOfParseCall ?: $res)
 			);
 		}
-		$this->assertEquals(
+		// Inline-emission refactor: modal markup is concatenated into the parse
+		// result instead of being stashed via parserOutputHelper->injectLater().
+		// Assert the modal substring appears in the same output the trigger does.
+		$this->assertStringContainsString(
 			$expectedModal,
-			$modalInjection,
+			$resultOfParseCall ?: $res,
 			'failed modal with test data:' . $this->generatePhpCodeForManualProviderDataOneCase( $fp, $hp )
 		);
 	}

--- a/tests/phpunit/Unit/ImageModalTriggerTest.php
+++ b/tests/phpunit/Unit/ImageModalTriggerTest.php
@@ -3,7 +3,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\ImageModalTrigger;
-use \MediaWiki\MediaWikiServices;
+use MediaWiki\MediaWikiServices;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/phpunit/Unit/ImageModalTriggerTest.php
+++ b/tests/phpunit/Unit/ImageModalTriggerTest.php
@@ -172,7 +172,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page' => false,
 				],
 				[
-					'~<span class="modal-trigger" data-toggle="modal" data-target="#id"><img src="thumbnail::toHtml\(\)/return/value\.png" ></span>~',
+					'~<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id"><img src="thumbnail::toHtml\(\)/return/value\.png" ></span>~',
 				]
 			],
 			'frame params w/o thumbnail'     => [
@@ -192,7 +192,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page' => false,
 				],
 				[
-					'~<div class="floatleft"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
+					'~<div class="floatleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id">~',
 					'~<img src="thumbnail::toHtml\(\)/return/value\.png" alt="test_alt" title="test_title" class="test_class">~',
 				]
 			],
@@ -214,7 +214,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page'  => 7,
 				],
 				[
-					'~<div class="floatleft"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
+					'~<div class="floatleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id">~',
 					'~<img src="thumbnail::toHtml\(\)/return/value\.png" >~',
 				]
 			],
@@ -236,7 +236,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page'  => 7,
 				],
 				[
-					'~<div class="thumb tmiddle"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
+					'~<div class="thumb tmiddle"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id">~',
 					'~<div class="thumbinner" style="width:642px;"><img src="thumbnail::toHtml\(\)/return/value\.png" class="thumbimage">~',
 					'~<div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge">~',
 				]
@@ -260,9 +260,9 @@ class ImageModalTriggerTest extends TestCase {
 					'page' => false,
 				],
 				[
-					'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
+					'~<div class="thumb tnone"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id">~',
 					'~<div class="thumbinner" style="width:96px;">~',
-					'~<img alt="" src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage" />~',
+					'~<img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?>~',
 				]
 			],
 			'framed'                         => [
@@ -282,7 +282,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page' => false,
 				],
 				[
-					'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
+					'~<div class="thumb tnone"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id">~',
 					'~<div class="thumbinner" style="width:642px;"><img src="thumbnail::toHtml\(\)/return/value\.png" class="thumbimage">~',
 				]
 			],
@@ -304,7 +304,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page'  => false,
 				],
 				[
-					'~<div class="center"><span class="modal-trigger" data-toggle="modal" data-target="#id"><img src="thumbnail::toHtml\(\)/return/value\.png" >~',
+					'~<div class="center"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id"><img src="thumbnail::toHtml\(\)/return/value\.png" >~',
 				]
 			],
 			'manual thumbnail, upright'      => [
@@ -326,8 +326,8 @@ class ImageModalTriggerTest extends TestCase {
 					'page' => false,
 				],
 				[
-					'~<div class="thumb tleft"><span class="modal-trigger" data-toggle="modal" data-target="#id"><div class="thumbinner" style="width:96px;">~',
-					'~<img alt="" src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage" />~',
+					'~<div class="thumb tleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id"><div class="thumbinner" style="width:96px;">~',
+					'~<img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?>~',
 					'~<div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge">~',
 				]
 			],

--- a/tests/phpunit/Unit/LuaLibraryTestBase.php
+++ b/tests/phpunit/Unit/LuaLibraryTestBase.php
@@ -3,7 +3,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\LuaLibrary;
-use \Scribunto_LuaEngineTestBase;
+use MediaWiki\Extension\Scribunto\Tests\Engines\LuaCommon\LuaEngineTestBase;
 
 /**
  * @ingroup Test
@@ -15,7 +15,7 @@ use \Scribunto_LuaEngineTestBase;
  * @since   1.1
  * @author  Tobias Oetterer
  */
-abstract class LuaLibraryTestBase extends Scribunto_LuaEngineTestBase
+abstract class LuaLibraryTestBase extends LuaEngineTestBase
 {
 	/**
 	 * @var LuaLibrary

--- a/tests/phpunit/Unit/ModalBuilderTest.php
+++ b/tests/phpunit/Unit/ModalBuilderTest.php
@@ -100,9 +100,9 @@ class ModalBuilderTest extends TestCase {
 				'outerClass0',
 				'outerStyle0',
 				'innerClass0',
-				'<span class="modal-trigger" data-toggle="modal" data-target="#id0">trigger0</span>',
+				'<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id0">trigger0</span>',
 				'<div class="modal fade outerClass0" style="outerStyle0" role="dialog" id="id0" aria-hidden="true"><div class="modal-dialog innerClass0"><div class="modal-content"><div class="modal-header"><span class="modal-title">header0</span>'
-				. '<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div><div class="modal-body">content0</div><div class="modal-footer">footer0<button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				. '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div><div class="modal-body">content0</div><div class="modal-footer">footer0<button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'scarce' => [
 				'id1',
@@ -113,9 +113,9 @@ class ModalBuilderTest extends TestCase {
 				'',
 				'',
 				'',
-				'<span class="modal-trigger" data-toggle="modal" data-target="#id1">trigger1</span>',
-				'<div class="modal fade" role="dialog" id="id1" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close">'
-				. '<span aria-hidden="true">&times;</span></button></div><div class="modal-body">content1</div><div class="modal-footer"><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id1">trigger1</span>',
+				'<div class="modal fade" role="dialog" id="id1" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">'
+				. '</button></div><div class="modal-body">content1</div><div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 		];
 	}

--- a/tests/phpunit/Unit/ModalBuilderTest.php
+++ b/tests/phpunit/Unit/ModalBuilderTest.php
@@ -49,15 +49,9 @@ class ModalBuilderTest extends TestCase {
 	 */
 	public function testCanParse( $id, $trigger, $content, $header, $footer, $outerClass, $outerStyle, $innerClass, $expectedTrigger, $expectedModal ) {
 
-		$modalInjection = '';
 		$parserOutputHelper = $this->getMockBuilder( 'MediaWiki\\Extension\\BootstrapComponents\\ParserOutputHelper' )
 			->disableOriginalConstructor()
 			->getMock();
-		$parserOutputHelper->expects( $this->any() )
-			->method( 'injectLater' )
-			->will( $this->returnCallback( function( $id, $text ) use ( &$modalInjection ) {
-				$modalInjection .= $text;
-			} ) );
 
 		/** @noinspection PhpParamsInspection */
 		$instance = new ModalBuilder( $id, $trigger, $content, $parserOutputHelper );
@@ -76,13 +70,13 @@ class ModalBuilderTest extends TestCase {
 		if ( $innerClass ) {
 			$instance->setDialogClass( $innerClass );
 		}
+		// Inline-emission refactor: parse() now returns the trigger HTML and
+		// modal container HTML concatenated, so they emit as siblings at the
+		// wikitext tag's natural position. Previously the trigger was returned
+		// and the modal was stashed via parserOutputHelper->injectLater().
 		$this->assertEquals(
-			$expectedTrigger,
+			$expectedTrigger . $expectedModal,
 			$instance->parse()
-		);
-		$this->assertEquals(
-			$expectedModal,
-			$modalInjection
 		);
 	}
 

--- a/tests/phpunit/Unit/ParserOutputHelperTest.php
+++ b/tests/phpunit/Unit/ParserOutputHelperTest.php
@@ -4,10 +4,9 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
-use \MWException;
-// TODO: when dropping 1.39, switch to MediaWiki\Parser\Parser and MediaWiki\Parser\ParserOutput
-use Parser;
-use ParserOutput;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOutput;
+use MWException;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/phpunit/Unit/ParserRequestTest.php
+++ b/tests/phpunit/Unit/ParserRequestTest.php
@@ -3,9 +3,9 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\ParserRequest;
+use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
-use \Parser;
-use \PPFrame;
+use PPFrame;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\ParserRequest

--- a/tests/phpunit/Unit/mw.bootstrap.parse.tests.lua
+++ b/tests/phpunit/Unit/mw.bootstrap.parse.tests.lua
@@ -55,7 +55,7 @@ local tests = {
 			return removeId ( mw.bootstrap.parse( component, input, args ) )
 		end,
 		args = { 'alert', 'Alert content', { color = 'success', dismissible = 'fade', noStrip = true } },
-		expect = { '<div class="alert alert-success alert-dismissible fade show" role="alert">Alert content<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>' }
+		expect = { '<div class="alert alert-success alert-dismissible fade show" role="alert">Alert content<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>' }
 	},
 }
 


### PR DESCRIPTION
Closes #38.
Fixes #68.

## Summary

Upgrades BootstrapComponents from Bootstrap 4 to Bootstrap 5.3, at functional parity with the last released BS4-era BC (5.2.2) and additionally resolves the upstream "Modal/Popover/Tooltip stop working under MediaWiki 1.43+" bug.

This branch was informed by the earlier WIP exploration in #69 (now closed as superseded); it is a clean, self-contained set of nine commits.

## What changed

Nine self-contained commits:

1. **Migrate BootstrapComponents to Bootstrap 5.3** — the BS4 → 5.3 emission changes (`data-toggle` → `data-bs-toggle` family, `.btn-default` → `.btn-secondary` mapping for `color="default"`, `.close` → `.btn-close`, `.badge-pill` → `.rounded-pill`, jumbotron utility-class reimplementation per the BS5 migration guide, vanilla-JS rewrites of carousel/popover/tooltip). Floor versions bumped to MW ≥ 1.43, PHP ≥ 8.1, `mediawiki/bootstrap: ^6.0`.
2. **Run CI on more versions of MediaWiki and PHP** — CI matrix updated to MW 1.43–1.45 + master, PHP 8.1–8.5.
3. **Modernise namespaced class imports** — `use \Html` etc. replaced with `use MediaWiki\…\X` across the codebase (required-ish at the MW 1.43 floor).
4. **Update tests for Bootstrap 5 output** — PHPUnit expectations updated to match the BS5 emitted markup.
5. **Fix DOMContentLoading typo in tooltip JS initialiser** — `'DOMContentLoading'` (which is not an event) is now `'DOMContentLoaded'`.
6. **Resolve upstream #68 by emitting modal markup inline** — the architectural fix; see below.
7. **Emit Bootstrap 5 `text-bg-<color>` for badges** — BS5 removed the `.badge-<color>` family; replaced with `.text-bg-<color>`. `color="default"` maps to `text-bg-secondary` for backward-compat (matches Button/Modal/Popover behaviour).
8. **Update tests to match inline modal emission** — ModalTest, ImageModalTest, ModalBuilderTest, OutputPageParserOutputTest contract changes.
9. **docs: update component references for Bootstrap 5** — every external `https://getbootstrap.com/docs/4.1/` link bumped to `/docs/5.3/`; jumbotron deprecation banner; `color="default"` mapping noted in the relevant component docs; `known-issues.md` updated with the #68 resolution note; release-notes 6.0 entry expanded.

## Resolves upstream issue #68

PR #69 noted "Modal does not trigger" / "Popover does not trigger" as a TODO. Investigation showed it is the same bug as the open issue #68 ("Tooltip, Popover and Modal stop working after a cache purge on MW 1.43.3").

Root cause: BC's `ModalBuilder::parse()` stashed the modal markup via `ParserOutputHelper::injectLater()` → `$parserOutput->setExtensionData(DEFERRED_CONTENT_KEY, …)`, and `OutputPageParserOutput::process()` retrieved it via the same key at render time. Diagnostic instrumentation under MW 1.43.8 showed the parse-time and render-time `ParserOutput` instances are **different objects** (`spl_object_id` differs); the deferred-content data set on the parse-time object never reaches the render-time hook. Effect: trigger renders, modal container does not, click does nothing.

The defensive design rationale for the deferred-injection pattern no longer applies under modern MediaWiki + Bootstrap 5 — MW 1.40+ uses RemexHtml which auto-closes the enclosing inline element rather than mangling block-in-inline, and BS5 modals use `position: fixed` plus an ID-resolving `data-bs-target` attribute so DOM placement is no longer significant.

Refactor: emit the modal markup inline as a sibling of its trigger button. Per-component JS init modules (the BS5 vanilla-JS replacements for the dropped jQuery plugins) are loaded via `OutputPage::addModules()` from the `OutputPageParserOutput` hook (which works reliably; `OutputPage` is the persistent object). A new `ext.bootstrapComponents.modal.js` module explicitly instantiates `bootstrap.Modal` on each `.modal` element, since BS5 dropped the BS4 jQuery-driven autoinit.

The same patch was applied workspace-only against BC 5.2.2 to confirm: with this commit, modal markup renders on MW 1.43+ even without the BS5 migration. So the fix would also help users still on BC 5.2.x if backported.

## Verification

- **4-stack harness** (Chameleon-BS4 / Chameleon-BS5 / Medik-BS4 / Medik-BS5 on MW 1.43.8): every parser function renders correctly on every stack; HTTP 200; no PHP errors; zero unparsed parser-function tokens.
- **Comprehensive per-attribute matrix** (~75 attribute permutations: 8 colors × every component, all sizes, all placements/triggers for popover/tooltip, outline/pill/active/disabled variants, custom-class/style passthrough): no functional regressions on any stack.
- **Functional triggering** verified via Playwright on the BS5 candidate stacks: modal `data-bs-toggle` click opens the modal (with backdrop, `.modal.fade.show`); popover and tooltip JS instances attach; dismissible alert `.btn-close` closes the alert.
- **PHPUnit:** 96 of BC's Unit/ tests pass (everything except `LuaLibrary*Test.php` which require Scribunto in the test environment).

## Component deprecations (BS5)

- `bootstrap_jumbotron` — BS5 removed the `.jumbotron` class ([migration guide entry](https://getbootstrap.com/docs/5.3/migration/#jumbotron)). The parser function is retained and now emits the BS5 utility-class approximation per the migration guide (`p-5 mb-4 bg-body-tertiary rounded-3`). The deprecation is called out in [docs/components/jumbotron.md](docs/components/jumbotron.md) and [docs/components.md](docs/components.md); the parser function may be removed in a future major release.

## Notes for users

- `mediawiki/bootstrap` constraint pins to `^6.0` (the released BS5.3-bearing major). Anyone on the previous `^5.0` is on a BS4 stack and should stay on BC 5.x until ready to upgrade their wiki to MW 1.43+ + the new Bootstrap extension major.
- Most existing wiki markup using BC parser functions / tag extensions continues to work without changes. `color="default"` automatically maps to `btn-secondary` (button/modal/popover/badge).

## Out of scope

- Adding new BS5-only components (`bootstrap_offcanvas`, `bootstrap_spinner`, `bootstrap_toast`) — separate enhancement.
- Audit of BC's `*.vector-fix.css` modules for continued necessity under BS5 — separate follow-up.
- Migrating `MWException` to typed exceptions — latent debt, separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

