### PR TITLE
Fix modal trigger not opening modals on MediaWiki 1.43+

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -107,7 +107,7 @@ class ApplicationFactory {
 	 * @param string             $id
 	 * @param string             $trigger must be safe raw html (best run through {@see Parser::recursiveTagParse})
 	 * @param string             $content must be safe raw html (best run through {@see Parser::recursiveTagParse})
-	 * @param ParserOutputHelper $parserOutputHelper
+	 * @param ParserOutputHelper $parserOutputHelper @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
 	 *
 	 * @see ModalBuilder::__construct
 	 *

--- a/src/BootstrapComponents.php
+++ b/src/BootstrapComponents.php
@@ -56,8 +56,6 @@ use MWException;
  */
 class BootstrapComponents {
 
-	const EXTENSION_DATA_DEFERRED_CONTENT_KEY = 'bsc_deferredContent';
-
 	const EXTENSION_DATA_NO_IMAGE_MODAL = 'bsc_no_image_modal';
 
 

--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -26,7 +26,6 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Hooks;
 
-use MediaWiki\Extension\BootstrapComponents\BootstrapComponents;
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 /*
  * TODO switch to these, wehen we drop support for mw < 1.40
@@ -41,24 +40,11 @@ use \ParserOutput;
  *
  * Called after parse, before the HTML is added to the output.
  *
- * Method delegated to separate class to fix missing (deferred) content in
- * {@see \MediaWiki\Extension\BootstrapComponents\Tests\Integration\BootstrapComponentsJSONScriptTestCaseRunnerTest::assertParserOutputForCase}
- *
  * @see   https://www.mediawiki.org/wiki/Manual:Hooks/OutputPageParserOutput
  *
  * @since 1.2
  */
 class OutputPageParserOutput {
-
-	/**
-	 * @var string
-	 */
-	const INJECTION_PREFIX = '<!-- injected by Extension:BootstrapComponents -->';
-
-	/**
-	 * @var string
-	 */
-	const INJECTION_SUFFIX = '<!-- /injected by Extension:BootstrapComponents -->';
 
 	/**
 	 * @var BootstrapComponentsService
@@ -72,6 +58,8 @@ class OutputPageParserOutput {
 
 	/**
 	 * @var ParserOutput $parserOutput
+	 *
+	 * @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
 	 */
 	private ParserOutput $parserOutput;
 
@@ -79,7 +67,7 @@ class OutputPageParserOutput {
 	 * OutputPageParserOutput constructor.
 	 *
 	 * @param OutputPage $outputPage
-	 * @param ParserOutput $parserOutput
+	 * @param ParserOutput $parserOutput @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
 	 * @param BootstrapComponentsService $service
 	 */
 	public function __construct(
@@ -94,34 +82,9 @@ class OutputPageParserOutput {
 	 * @return void
 	 */
 	public function process(): void	{
-		$deferredText = $this->getContentForLaterInjection( $this->getParserOutput() );
-		if ( !empty( $deferredText ) ) {
-			$this->getOutputPage()->addHTML( $deferredText );
-		}
-
 		if ( $this->getBootstrapComponentsService()->vectorSkinInUse() ) {
 			$this->getOutputPage()->addModules( [ 'ext.bootstrapComponents.vector-fix' ] );
 		}
-	}
-
-	/**
-	 * Returns the raw html that is to be inserted at the end of the page.
-	 *
-	 * @param ParserOutput $parserOutput
-	 *
-	 * @return string
-	 */
-	protected function getContentForLaterInjection( ParserOutput $parserOutput ): string {
-		$deferredContent = $parserOutput
-			->getExtensionData(BootstrapComponents::EXTENSION_DATA_DEFERRED_CONTENT_KEY );
-
-		if ( empty( $deferredContent ) || !is_array( $deferredContent ) ) {
-			return '';
-		}
-
-		// clearing extension data for unit and integration tests to work
-		$parserOutput->setExtensionData( BootstrapComponents::EXTENSION_DATA_DEFERRED_CONTENT_KEY, null );
-		return self::INJECTION_PREFIX . implode( array_values( $deferredContent ) ) . self::INJECTION_SUFFIX;
 	}
 
 	protected function getBootstrapComponentsService(): BootstrapComponentsService {
@@ -136,6 +99,8 @@ class OutputPageParserOutput {
 	}
 
 	/**
+	 * @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
+	 *
 	 * @return ParserOutput
 	 */
 	protected function getParserOutput(): ParserOutput {

--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -102,6 +102,8 @@ class ModalBuilder {
 
 	/**
 	 * @var ParserOutputHelper $parserOutputHelper
+	 *
+	 * @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
 	 */
 	private $parserOutputHelper;
 
@@ -146,7 +148,7 @@ class ModalBuilder {
 	 * @param string             $id
 	 * @param string             $trigger must be safe raw html (best run through {@see Parser::recursiveTagParse})
 	 * @param string             $content must be fully parsed html (use {@see Parser::recursiveTagParseFully})
-	 * @param ParserOutputHelper $parserOutputHelper
+	 * @param ParserOutputHelper $parserOutputHelper @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
 	 *
 	 * @see ApplicationFactory::getNewModalBuilder
 	 * @see Components\Modal::generateButton
@@ -163,14 +165,14 @@ class ModalBuilder {
 	/**
 	 * Parses the modal.
 	 *
+	 * Emits the trigger followed by the modal container inline. The container is
+	 * `position: fixed` and is addressed via `data-target="#id"`, so its DOM
+	 * placement is not significant.
+	 *
 	 * @return string
 	 */
 	public function parse() {
-		$this->parserOutputHelper->injectLater(
-			$this->getId(),
-			$this->buildModal()
-		);
-		return $this->buildTrigger();
+		return $this->buildTrigger() . $this->buildModal();
 	}
 
 	/**

--- a/src/ParserOutputHelper.php
+++ b/src/ParserOutputHelper.php
@@ -139,30 +139,6 @@ class ParserOutputHelper {
 	}
 
 	/**
-	 * Allows for html fragments for a given container id to be stored, so that it can be added to the page at a later time.
-	 *
-	 * @param string $id
-	 * @param string $rawHtml
-	 *
-	 * @return ParserOutputHelper $this (fluid)
-	 */
-	public function injectLater( $id, $rawHtml ) {
-		if ( empty( $this->getParser()->getOutput() ) ) {
-			# fix issues with PageForms file upload (issue #20)
-			return $this;
-		}
-		if ( !empty( $rawHtml ) ) {
-			$deferredContent = $this->getParser()->getOutput()->getExtensionData( BootstrapComponents::EXTENSION_DATA_DEFERRED_CONTENT_KEY );
-			if ( empty( $deferredContent ) ) {
-				$deferredContent = [];
-			}
-			$deferredContent[$id] = $rawHtml;
-			$this->getParser()->getOutput()->setExtensionData( BootstrapComponents::EXTENSION_DATA_DEFERRED_CONTENT_KEY, $deferredContent );
-		}
-		return $this;
-	}
-
-	/**
 	 * Formats a text as error text, so it can be added to the output.
 	 *
 	 * @param string $errorMessageName

--- a/tests/phpunit/Unit/Components/ModalTest.php
+++ b/tests/phpunit/Unit/Components/ModalTest.php
@@ -49,15 +49,9 @@ class ModalTest extends ComponentsTestBase {
 	 */
 	public function testCanRender( $input, $arguments, $expectedTriggerOutput, $expectedModalOutput ) {
 
-		$modalInjection = '';
 		$parserOutputHelper = $this->getMockBuilder( 'MediaWiki\\Extension\\BootstrapComponents\\ParserOutputHelper' )
 			->disableOriginalConstructor()
 			->getMock();
-		$parserOutputHelper->expects( $this->any() )
-			->method( 'injectLater' )
-			->will( $this->returnCallback( function( $id, $text ) use ( &$modalInjection ) {
-				$modalInjection .= $text;
-			} ) );
 		$parserOutputHelper->expects( $this->any() )
 			->method( 'renderErrorMessage' )
 			->will( $this->returnArgument( 0 ) );
@@ -74,11 +68,7 @@ class ModalTest extends ComponentsTestBase {
 		/** @noinspection PhpParamsInspection */
 		$generatedOutput = $instance->parseComponent( $parserRequest );
 
-		$this->assertEquals( $expectedTriggerOutput, $generatedOutput );
-		$this->assertEquals(
-			$expectedModalOutput,
-			$modalInjection
-		);
+		$this->assertEquals( $expectedTriggerOutput . $expectedModalOutput, $generatedOutput );
 	}
 
 	/**

--- a/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
@@ -39,40 +39,43 @@ class OutputPageParserOutputTest extends TestCase {
 		);
 	}
 
-	public function testHookOutputPageParserOutput() {
-		$content = 'CONTENT';
-
+	public function testHookOutputPageParserOutputLoadsVectorFixUnderVector() {
 		$outputPage = $this->createMock( OutputPage::class );
-		$outputPage->expects( $this->once() )
-			->method( 'addHTML' )
-			->will( $this->returnCallback( function( $injection ) use ( &$content ) {
-				$content .= $injection;
-			} ) );
+		$outputPage->expects( $this->never() )->method( 'addHTML' );
 		$outputPage->expects( $this->once() )
 			->method( 'addModules' )
 			->with(
 				$this->equalTo( [ 'ext.bootstrapComponents.vector-fix' ] )
 			);
 
-		$observerParserOutput = $this->createMock( ParserOutput::class );
-		$observerParserOutput->expects( $this->exactly( 1 ) )
-			->method( 'getExtensionData' )
-			->with(
-				$this->stringContains( 'bsc_deferredContent' )
-			)
-			->willReturn( [ 'test' ] );
-
 		$bootstrapService = $this->createMock( BootstrapComponentsService::class );
 		$bootstrapService->expects( $this->once() )
 			->method( 'vectorSkinInUse' )
 			->willReturn( true );
 
-		$instance = new OutputPageParserOutput( $outputPage, $observerParserOutput, $bootstrapService );
-		$instance->process();
-
-		$this->assertEquals(
-			'CONTENT<!-- injected by Extension:BootstrapComponents -->test<!-- /injected by Extension:BootstrapComponents -->',
-			$content
+		$instance = new OutputPageParserOutput(
+			$outputPage,
+			$this->createMock( ParserOutput::class ),
+			$bootstrapService
 		);
+		$instance->process();
+	}
+
+	public function testHookDoesNothingWhenNotVector() {
+		$outputPage = $this->createMock( OutputPage::class );
+		$outputPage->expects( $this->never() )->method( 'addHTML' );
+		$outputPage->expects( $this->never() )->method( 'addModules' );
+
+		$bootstrapService = $this->createMock( BootstrapComponentsService::class );
+		$bootstrapService->expects( $this->once() )
+			->method( 'vectorSkinInUse' )
+			->willReturn( false );
+
+		$instance = new OutputPageParserOutput(
+			$outputPage,
+			$this->createMock( ParserOutput::class ),
+			$bootstrapService
+		);
+		$instance->process();
 	}
 }

--- a/tests/phpunit/Unit/ImageModalTest.php
+++ b/tests/phpunit/Unit/ImageModalTest.php
@@ -254,13 +254,7 @@ class ImageModalTest extends TestCase {
 				}
 			) );
 
-		$modalInjection = '';
 		$parserOutputHelper = $this->createMock( ParserOutputHelper::class );
-		$parserOutputHelper->expects( $this->any() )
-			->method( 'injectLater' )
-			->will( $this->returnCallback( function( $id, $text ) use ( &$modalInjection ) {
-				$modalInjection .= $text;
-			} ) );
 
 		$instance = $this->createImageModalWithMocks( null, $title, $file, $nestingController, null, $parserOutputHelper );
 		$time = false;
@@ -283,9 +277,9 @@ class ImageModalTest extends TestCase {
 				. '--  ' . ($resultOfParseCall ?: $res)
 			);
 		}
-		$this->assertEquals(
+		$this->assertStringContainsString(
 			$expectedModal,
-			$modalInjection,
+			$resultOfParseCall ?: $res,
 			'failed modal with test data:' . $this->generatePhpCodeForManualProviderDataOneCase( $fp, $hp )
 		);
 	}

--- a/tests/phpunit/Unit/ModalBuilderTest.php
+++ b/tests/phpunit/Unit/ModalBuilderTest.php
@@ -49,15 +49,9 @@ class ModalBuilderTest extends TestCase {
 	 */
 	public function testCanParse( $id, $trigger, $content, $header, $footer, $outerClass, $outerStyle, $innerClass, $expectedTrigger, $expectedModal ) {
 
-		$modalInjection = '';
 		$parserOutputHelper = $this->getMockBuilder( 'MediaWiki\\Extension\\BootstrapComponents\\ParserOutputHelper' )
 			->disableOriginalConstructor()
 			->getMock();
-		$parserOutputHelper->expects( $this->any() )
-			->method( 'injectLater' )
-			->will( $this->returnCallback( function( $id, $text ) use ( &$modalInjection ) {
-				$modalInjection .= $text;
-			} ) );
 
 		/** @noinspection PhpParamsInspection */
 		$instance = new ModalBuilder( $id, $trigger, $content, $parserOutputHelper );
@@ -77,12 +71,8 @@ class ModalBuilderTest extends TestCase {
 			$instance->setDialogClass( $innerClass );
 		}
 		$this->assertEquals(
-			$expectedTrigger,
+			$expectedTrigger . $expectedModal,
 			$instance->parse()
-		);
-		$this->assertEquals(
-			$expectedModal,
-			$modalInjection
 		);
 	}
 


### PR DESCRIPTION
Partial fix for #68 — addresses the modal symptom only. The tooltip and popover symptoms of #68 will follow in a separate PR.

The deferred-content mechanism that historically passed modal markup from the parser hook to `OutputPageParserOutput` via `ParserOutput::setExtensionData` no longer works under **MediaWiki 1.43+** — the `ParserOutputAccess` lifecycle changes between 1.39 and 1.43 mean the set-side and get-side operate on different `ParserOutput` instances. The modal trigger renders, but the modal container never reaches the page.

This PR switches `ModalBuilder::parse()` to inline emission: trigger HTML and modal container HTML are returned concatenated. The modal container is `position: fixed` and addressed via `data-target="#id"`, so its DOM placement is irrelevant; it can sit as a sibling of its trigger in the article body. Block-in-inline placements are handled cleanly by RemexHtml (default since MW 1.36).

## Scope

- 5 source files: `ModalBuilder.php`, `ParserOutputHelper.php`, `BootstrapComponents.php`, `Hooks/OutputPageParserOutput.php`, `ApplicationFactory.php`
- 4 parallel test files updated for the new return-string shape

Net: **+41 / −123 lines**. No JS, CSS, or extension.json changes — purely the deferred-content rewrite.

Two now-unused fields (`ModalBuilder::$parserOutputHelper`, `OutputPageParserOutput::$parserOutput`) and their associated constructor parameters / getter are marked `@deprecated` rather than removed, so this stays a SemVer-clean maintenance fix. They will be dropped in the next major release.

## Verification

Click the trigger on a wikitext-`<bootstrap_modal>` page on two stacks (MW 1.43.8 + Chameleon BS4 baseline; MW 1.39.13 + Vector), with and without the patch:

|                                       | Unpatched (`master` tip)                          | Patched (this PR)                                  |
|---------------------------------------|---------------------------------------------------|----------------------------------------------------|
| **MW 1.43.8** (where #68 manifests)   | <img width="1920" height="1080" alt="pr-03-mw143-unpatched-broken" src="https://github.com/user-attachments/assets/c3784b31-2272-4157-af15-360104fd4338" /><br><sub>click does nothing — modal div absent from DOM</sub> | <img width="1920" height="1080" alt="pr-04-mw143-patched-modal-open" src="https://github.com/user-attachments/assets/ffcaac1f-3b42-47db-bec6-abaec8ad57c0" />
<br><sub>modal opens</sub> |
| **MW 1.39.13** (oldest supported)     | <img width="1920" height="1080" alt="pr-05-mw139-unpatched-modal-open" src="https://github.com/user-attachments/assets/e7a2c449-8828-4a03-9f84-f89cf948ced6" /><br><sub>modal opens — bug doesn't manifest on this MW</sub> | <img width="1920" height="1080" alt="pr-02-mw139-patched-modal-open" src="https://github.com/user-attachments/assets/093efa90-55ef-4aad-8c7a-8def63fea7c9" /><br><sub>modal still opens — no regression</sub> |


A Vector-only CSS override in BC suppresses the modal-backdrop on Vector (`ext.bootstrapComponents.modal.vector-fix.css`), so the bottom-row 1.39 screenshots show no dim overlay while the top-row 1.43/Chameleon shots do — that's pre-existing skin-specific styling, unchanged by this PR.

## Tests

PHPUnit unit suite (`--group mediawiki-databaseless`):

|                              | Tests | Failures |
|------------------------------|------:|---------:|
| Baseline (master tip)        | 337   | 6        |
| Patched                      | 338   | 6        |

Identical 6 failures in both runs — all in `BootstrapComponentsServiceTest` and `ImageModalTriggerTest` (`manual thumbnail` variants). All pre-existing, unrelated to the modal-builder path. (+1 test count comes from splitting `OutputPageParserOutputTest::testHookOutputPageParserOutput` into the two assertions that survive the inline-emission refactor.)

## Why a standalone fix

PR #74 ports BC to Bootstrap 5 and contains an equivalent modal-fix commit. Splitting this fix out lets BC 5.2.x ship a 5.2.3 maintenance release with just the MW 1.43+ unblocker for sites not yet ready for the BS5 migration.

The fix is BS-version-independent: under both BS4 and BS5 the modal container is `position: fixed`, so inline emission works identically on either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






