### PR TITLE
CI: disable Composer audit.block-insecure to ride out advisory waves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
           extensions: mbstring, intl
           tools: composer
 
+      - name: Disable Composer block-insecure
+        working-directory: ~
+        run: composer config --global audit.block-insecure false
+
       - name: Cache MediaWiki
         id: cache-mediawiki
         uses: actions/cache@v4


### PR DESCRIPTION
## Why

Three new `symfony/yaml` advisories landed on Packagist on 2026-05-20:

- `PKSA-v5yj-8nmz-sk2q` — CVE-2026-45304 ("Billion Laughs" exponential memory)
- `PKSA-ft77-7h5f-p3r6` — CVE-2026-45305 (ReDoS in `Parser::cleanup()`)
- `PKSA-b14r-zh1d-vdrc` — CVE-2026-45133 (stack exhaustion via unbounded recursion)

They flag the exact `symfony/yaml` versions pinned by every MediaWiki branch in the CI matrix — 5.4.23 on REL1_39, 5.4.45 on REL1_43, etc. Composer's `audit.block-insecure` default refuses to load any flagged package, so `composer update` (and `composer install` inside `installWiki.sh` on cache miss) now fails for every PR with:

```
- Root composer.json requires symfony/yaml 5.4.23 (exact version match: 5.4.23 or 5.4.23.0),
  found symfony/yaml[v5.4.23] but these were not loaded, because they are affected by
  security advisories (...).
```

Visible casualty: #75. Master will trip on it the next time CI runs too.

Cache-busting won't help here — REL1_39–REL1_42 are EOL and don't have the upstream `"audit": {"block-insecure": false}` backport that REL1_43+/master got via [Phabricator T416518](https://phabricator.wikimedia.org/T416518) / [commit ef90ede](https://github.com/wikimedia/mediawiki/commit/ef90ede). Refetching them gets the same vulnerable pin back.

## What

Add one step right after `Setup PHP`: `composer config --global audit.block-insecure false`. It writes to `~/.composer/config.json`, so every subsequent composer invocation in the same job — both `composer install` inside `installWiki.sh` (cache-miss path) and the workflow's own `composer update` (cache-hit path) — inherits the flag and ignores the advisory block.

It mirrors at the CI layer what the upstream MediaWiki backport (T416518) already does inside `mediawiki/core/composer.json` on REL1_43+ / master.

Three lines of YAML, no other changes. Once this merges, #75 (and any other open PR) should go green on rebase / rerun without further changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)