### PR TITLE
Detect the PHPUnit runner for MediaWiki 1.46+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             php: 8.3
             type: normal
             experimental: false
-          - mw: 'master'
+          - mw: 'REL1_46'
             php: 8.4
             type: normal
             experimental: true
@@ -95,12 +95,32 @@ jobs:
         run: bash EarlyCopy/.github/workflows/uploadImages.sh
 
       - if: env.TYPE != 'coverage'
-        name: Run PHPUnit w/o coverage
-        run: php tests/phpunit/phpunit.php -c extensions/BootstrapComponents/ --testsuite bootstrap-components-unit
+        name: Run PHPUnit
+        run: |
+          if [ -f tests/phpunit/phpunit.php ]; then
+            php tests/phpunit/phpunit.php -c extensions/BootstrapComponents/ --testsuite bootstrap-components-unit
+          else
+            # MW 1.46 and later
+            if [ ! -f phpunit.xml.template ]; then
+              wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
+            fi
+            composer phpunit:config
+            vendor/bin/phpunit -c phpunit.xml extensions/BootstrapComponents/tests/phpunit/Unit
+          fi
 
       - if: env.TYPE == 'coverage'
-        name: Run PHPUnit w/ coverage
-        run: php tests/phpunit/phpunit.php -c extensions/BootstrapComponents/ --testsuite bootstrap-components-unit --coverage-clover coverage.clover
+        name: Run PHPUnit (coverage)
+        run: |
+          if [ -f tests/phpunit/phpunit.php ]; then
+            php tests/phpunit/phpunit.php -c extensions/BootstrapComponents/ --testsuite bootstrap-components-unit --coverage-clover coverage.clover
+          else
+            # MW 1.46 and later
+            if [ ! -f phpunit.xml.template ]; then
+              wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
+            fi
+            composer phpunit:config
+            vendor/bin/phpunit -c phpunit.xml extensions/BootstrapComponents/tests/phpunit/Unit --coverage-clover coverage.clover
+          fi
 
       - if: env.TYPE == 'coverage'
         name: upload coverage report

--- a/tests/phpunit/Unit/LuaLibraryTestBase.php
+++ b/tests/phpunit/Unit/LuaLibraryTestBase.php
@@ -3,7 +3,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\LuaLibrary;
-use Scribunto_LuaEngineTestBase;
+use MediaWiki\Extension\Scribunto\Tests\Engines\LuaCommon\LuaEngineTestBase;
 
 /**
  * @ingroup Test
@@ -15,7 +15,7 @@ use Scribunto_LuaEngineTestBase;
  * @since   1.1
  * @author  Tobias Oetterer
  */
-abstract class LuaLibraryTestBase extends Scribunto_LuaEngineTestBase
+abstract class LuaLibraryTestBase extends LuaEngineTestBase
 {
 	/**
 	 * @var LuaLibrary


### PR DESCRIPTION
## Why

MediaWiki 1.46 removed the bundled `tests/phpunit/phpunit.php` runner in favour of
`composer phpunit:config` + `vendor/bin/phpunit`. The matrix's `master` row fails on
the old invocation (`Could not open input file: tests/phpunit/phpunit.php`); it only
looks green because it is `continue-on-error`.

## What

- **Detect the runner instead of gating on the MediaWiki version.** If
  `tests/phpunit/phpunit.php` exists, use it; otherwise drive PHPUnit through
  `composer phpunit:config` + `vendor/bin/phpunit`. No per-version bookkeeping as
  newer MediaWiki versions land.
- **Fetch `phpunit.xml.template` before `composer phpunit:config`.** MediaWiki marks
  it `export-ignore`, so it is absent from the source-archive tarball the install
  script downloads.
- **Scope the new runner to this extension's Unit suite by path** (the set the old
  `--testsuite bootstrap-components-unit` ran). The Integration tests `use`
  SemanticMediaWiki test traits, an optional dependency not installed in CI; PHPUnit
  loads those files during discovery, so they fatal at collection time before any
  group filter applies.
- **Use Scribunto's namespaced `LuaEngineTestBase`.** Scribunto dropped the legacy
  `Scribunto_LuaEngineTestBase` alias on master; the namespaced class is present on
  every supported MediaWiki (1.43 and up).
- **Add an experimental `REL1_46` row** so the new runner is exercised on a stable
  release branch as well as `master`.

## Scope and current state

The `REL1_43`, `REL1_44` and `REL1_45` rows keep the old runner unchanged and stay
green. The new runner now collects and runs on `1.46` and `master` instead of failing
at the entry point, but those rows stay `experimental` and red: this extension's unit
tests rely on the legacy entry point's full-MediaWiki bootstrap and error with
"Premature access to service container" under `vendor/bin/phpunit`. Making them green
is a separate test-suite modernization (proper `MediaWikiIntegrationTestCase` usage)
and is out of scope here; this change unblocks the runner and turns an opaque
entry-point failure into a real, visible test signal.

## Verifying

Local reproduction against MediaWiki master (1.47-alpha) with Scribunto, plus this
pull request's own CI run.
