### PR TITLE
[TEST — DO NOT MERGE] unified phpunit runner experiment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }} (TYPE ${{ matrix.type }})"
 
     strategy:
+      fail-fast: false  # [TEST BRANCH] show every entry's verdict, don't matrix-mate cancel
       matrix:
         include:
           - mw: 'REL1_39'
@@ -74,7 +75,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-experiment
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -103,12 +104,21 @@ jobs:
         run: bash EarlyCopy/.github/workflows/uploadImages.sh
 
       - if: env.TYPE != 'coverage'
-        name: Run PHPUnit w/o coverage
-        run: php tests/phpunit/phpunit.php -c extensions/BootstrapComponents/ --testsuite bootstrap-components-unit
+        name: '[TEST] Run PHPUnit (unified runner, --group mediawiki-databaseless)'
+        run: |
+          (composer phpunit:config 2>/dev/null || true)
+          vendor/bin/phpunit -c extensions/BootstrapComponents/phpunit.xml.dist \
+            --bootstrap tests/phpunit/bootstrap.php \
+            --group mediawiki-databaseless
 
       - if: env.TYPE == 'coverage'
-        name: Run PHPUnit w/ coverage
-        run: php tests/phpunit/phpunit.php -c extensions/BootstrapComponents/ --testsuite bootstrap-components-unit --coverage-clover coverage.clover
+        name: '[TEST] Run PHPUnit (unified runner, --group mediawiki-databaseless, coverage)'
+        run: |
+          (composer phpunit:config 2>/dev/null || true)
+          vendor/bin/phpunit -c extensions/BootstrapComponents/phpunit.xml.dist \
+            --bootstrap tests/phpunit/bootstrap.php \
+            --group mediawiki-databaseless \
+            --coverage-clover coverage.clover
 
       - if: env.TYPE == 'coverage'
         name: upload coverage report

--- a/.github/workflows/installWiki.sh
+++ b/.github/workflows/installWiki.sh
@@ -4,10 +4,9 @@ MW_BRANCH=$1
 EXTENSION_NAME=$2
 
 ## install core
-wget https://github.com/wikimedia/mediawiki/archive/${MW_BRANCH}.tar.gz -nv
-
-tar -zxf $MW_BRANCH.tar.gz
-mv mediawiki-$MW_BRANCH mediawiki
+# [TEST BRANCH] git clone instead of tarball — MW master needs
+# phpunit.xml.template which is export-ignored from the archive.
+git clone --depth 1 --branch "$MW_BRANCH" https://github.com/wikimedia/mediawiki.git mediawiki
 cd $MW_ROOT
 
 composer install


### PR DESCRIPTION
> ⚠️ **Throwaway experiment — do not merge.** Opened only to get a CI run; will be closed once we have the answer.

## Question we're answering

Does `--group mediawiki-databaseless` short-circuit PHPUnit's test discovery *before* the Scribunto-related hazards in BC's `LuaLibrary*` test files fire? I.e. does modern PHPUnit skip *loading* test files whose class-level `@group` doesn't match the filter, or does it load them all and only filter at the test-method level?

## What this does

Replaces all PHPUnit invocations in the matrix with one unified shape (Network-style):

```
(composer phpunit:config 2>/dev/null || true)
vendor/bin/phpunit \
  -c extensions/BootstrapComponents/phpunit.xml.dist \
  --bootstrap tests/phpunit/bootstrap.php \
  --group mediawiki-databaseless
```

Same line on every matrix entry. `composer phpunit:config` is a real script on master and a swallowed no-op on REL1_39–REL1_45.

Supporting changes:
- `installWiki.sh`: `git clone --depth 1` instead of `wget` tarball (so master has `phpunit.xml.template`).
- Cache key bumped to a one-off `-experiment` suffix so the new install actually runs.

## What we'll learn

For each matrix entry — green or red, and *which* failure mode:

| Entry | Earlier failure when we tried bare new-runner | If unified runner now passes |
|---|---|---|
| REL1_39 (coverage) | `LuaEngineTestBase::suite()` → `getParserFactory()` not registered | PHPUnit's `--group` filter is doing its job *before* class load |
| REL1_40–REL1_43 | (never reached — matrix-mate cancel) | Same |
| master | `Class "Scribunto_LuaEngineTestBase" not found` (Scribunto renamed) | Same |

If everything goes green, the path forward is the unified runner + `--group mediawiki-databaseless` on the entire matrix, no per-version splits, and PR #77 gets reframed accordingly. If anything stays red, that data narrows the actual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)