### PR TITLE
Load per-component JS init modules so tooltip/popover open on MediaWiki 1.43+

### DIFF
--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -82,6 +82,12 @@ class OutputPageParserOutput {
 	 * @return void
 	 */
 	public function process(): void	{
+		$this->getOutputPage()->addModules( [
+			'ext.bootstrapComponents.tooltip.fix',
+			'ext.bootstrapComponents.popover.fix',
+			'ext.bootstrapComponents.carousel.fix',
+		] );
+
 		if ( $this->getBootstrapComponentsService()->vectorSkinInUse() ) {
 			$this->getOutputPage()->addModules( [ 'ext.bootstrapComponents.vector-fix' ] );
 		}

--- a/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
@@ -39,14 +39,16 @@ class OutputPageParserOutputTest extends TestCase {
 		);
 	}
 
-	public function testHookOutputPageParserOutputLoadsVectorFixUnderVector() {
+	public function testProcessLoadsPerComponentInitModulesAndVectorFix() {
+		$loadedModules = [];
+
 		$outputPage = $this->createMock( OutputPage::class );
 		$outputPage->expects( $this->never() )->method( 'addHTML' );
-		$outputPage->expects( $this->once() )
+		$outputPage->expects( $this->atLeastOnce() )
 			->method( 'addModules' )
-			->with(
-				$this->equalTo( [ 'ext.bootstrapComponents.vector-fix' ] )
-			);
+			->will( $this->returnCallback( function( $modules ) use ( &$loadedModules ) {
+				$loadedModules = array_merge( $loadedModules, (array)$modules );
+			} ) );
 
 		$bootstrapService = $this->createMock( BootstrapComponentsService::class );
 		$bootstrapService->expects( $this->once() )
@@ -59,12 +61,28 @@ class OutputPageParserOutputTest extends TestCase {
 			$bootstrapService
 		);
 		$instance->process();
+
+		$expected = [
+			'ext.bootstrapComponents.tooltip.fix',
+			'ext.bootstrapComponents.popover.fix',
+			'ext.bootstrapComponents.carousel.fix',
+			'ext.bootstrapComponents.vector-fix',
+		];
+		sort( $loadedModules );
+		sort( $expected );
+		$this->assertEquals( $expected, $loadedModules );
 	}
 
-	public function testHookDoesNothingWhenNotVector() {
+	public function testProcessSkipsVectorFixWhenNotVector() {
+		$loadedModules = [];
+
 		$outputPage = $this->createMock( OutputPage::class );
 		$outputPage->expects( $this->never() )->method( 'addHTML' );
-		$outputPage->expects( $this->never() )->method( 'addModules' );
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'addModules' )
+			->will( $this->returnCallback( function( $modules ) use ( &$loadedModules ) {
+				$loadedModules = array_merge( $loadedModules, (array)$modules );
+			} ) );
 
 		$bootstrapService = $this->createMock( BootstrapComponentsService::class );
 		$bootstrapService->expects( $this->once() )
@@ -77,5 +95,7 @@ class OutputPageParserOutputTest extends TestCase {
 			$bootstrapService
 		);
 		$instance->process();
+
+		$this->assertNotContains( 'ext.bootstrapComponents.vector-fix', $loadedModules );
 	}
 }


### PR DESCRIPTION
Closes #68.

Completes the fix for #68 by resolving the tooltip, popover and carousel sub-bugs left out of #75 (which addressed only the modal symptom).

## Root cause

The per-component JS init modules `ext.bootstrapComponents.{tooltip,popover,carousel}.fix` each declare a `scripts:` entry in `extension.json` that initialises the Bootstrap library on the trigger elements (`.tooltip()`, `.popover()`, `.carousel()`). Without these modules reaching the page, hover on a `.bootstrap-tooltip` and click on a `[data-toggle="popover"]` do nothing.

`HooksHandler::onParserAfterParse` is supposed to load them via the `getActiveComponents()` foreach, but two issues break that path:

1. **Only `ImageModal` registers itself as active.** Tooltip, popover, and carousel parser hooks never call `registerComponentAsActive()`, so `getActiveComponents()` never contains them and the foreach never iterates over their modules.
2. Even when the foreach does run (for ImageModal), it calls **`addModuleStyles()`** — which loads only the CSS half. The `scripts:` half of a module never reaches the page through that call.

## Fix

Move per-component init module loading to `OutputPageParserOutput::process()`, where the three init modules are added unconditionally to the persistent `OutputPage` via `addModules()`. Each init script is a single jQuery selector + initializer call (`$('[data-toggle="tooltip"]').tooltip()` etc.); on a page without the matching trigger markup the selector returns an empty collection and the initializer no-ops. Per-request cost on tooltip/popover/carousel-free pages: three small DOM queries served from a cached ResourceLoader bundle — negligible.

## Scope

- 1 source file: `src/Hooks/OutputPageParserOutput.php` — adds one `addModules` call in `process()` listing the three per-component init modules
- 1 test file: `tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php` (rewritten the two `process()` cases to assert the union of `addModules` calls — same mocking pattern PR #75 used in `testHookOutputPageParserOutputLoadsModules`)

Net: **+37 / −7 lines.**

## Verification

Tested on **MW 1.43.8 + Chameleon BS4** (where the bug manifests) and on the oldest supported floor **MW 1.39.17** across three BS4 skins — Vector, Chameleon BS4, and Medik:

|                                       | Tooltip hover                                              | Popover click                                              |
|---------------------------------------|------------------------------------------------------------|------------------------------------------------------------|
| **MW 1.43.8** + Chameleon BS4         | <img width="1920" height="1080" alt="sub68-mw143-tooltip-hover" src="https://github.com/user-attachments/assets/1ae0e807-74c2-4eea-9ac9-5966df9c96a7" />|<img width="1920" height="1080" alt="sub68-mw143-popover-click" src="https://github.com/user-attachments/assets/d8b5821f-6065-4e4a-9670-cecd09b4c8d2" />|
| **MW 1.39.17** + Vector               |<img width="1920" height="1080" alt="sub68-mw139-tooltip-hover" src="https://github.com/user-attachments/assets/dc4f21ff-45b9-46aa-b4a5-19c19dbea4b5" />|<img width="1920" height="1080" alt="sub68-mw139-popover-click" src="https://github.com/user-attachments/assets/1d6d5e2a-25a7-4867-810d-b7d1fefc3718" />|
| **MW 1.39.17** + Chameleon BS4        |<img width="1920" height="1080" alt="sub68-mw139-chameleon-tooltip" src="https://github.com/user-attachments/assets/0ab021f0-10ce-4d91-b9c3-fac2b146a20a" />|<img width="1920" height="1080" alt="sub68-mw139-chameleon-popover" src="https://github.com/user-attachments/assets/e7ba284d-1ceb-4da5-aafb-7e27aa2c6f03" />|
| **MW 1.39.17** + Medik                |<img width="1920" height="1080" alt="sub68-mw139-medik-tooltip" src="https://github.com/user-attachments/assets/498c29e7-8c10-42db-afb9-df53e2ca4aae" />|<img width="1920" height="1080" alt="sub68-mw139-medik-popover" src="https://github.com/user-attachments/assets/6afa515c-4ea7-4e7e-a597-465039b7b505" />|


Module + instance state on both stacks after page load:

```
ext.bootstrap.scripts:                ready
ext.bootstrapComponents.tooltip.fix:  ready
ext.bootstrapComponents.popover.fix:  ready
ext.bootstrapComponents.carousel.fix: ready
jQuery(.bootstrap-tooltip).data("bs.tooltip"):   <object>
jQuery([data-toggle=popover]).data("bs.popover"): <object>
```

## Tests

PHPUnit (`--group mediawiki-databaseless`) on MW 1.39:

|        | Tests | Failures |
|--------|------:|---------:|
| Master (post-#75)   | 338 | 6 |
| Patched (this PR)   | 338 | 6 |

Same 6 pre-existing failures in `BootstrapComponentsServiceTest` / `ImageModalTriggerTest` / `ImageModalTest` (manual-thumbnail variants). All unrelated to the JS-init module path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







