### PR TITLE
Restore sparse per-component module loading

### DIFF
--- a/src/AbstractComponent.php
+++ b/src/AbstractComponent.php
@@ -26,6 +26,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
+use MediaWiki\MediaWikiServices;
 use \MWException;
 
 /**
@@ -153,6 +154,9 @@ abstract class AbstractComponent implements NestableInterface {
 			throw new MWException( 'Invalid ParserRequest supplied to component ' . $this->getComponentName() . '!' );
 		}
 		$this->getNestingController()->open( $this );
+		MediaWikiServices::getInstance()
+			->getService( 'BootstrapComponentsService' )
+			->registerComponentAsActive( $this->getComponentName() );
 		$this->initComponentData( $parserRequest );
 
 		$input = $this->prepareInput( $parserRequest );

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -228,6 +228,7 @@ class HooksHandler implements
 			}
 			foreach ( $this->getComponentLibrary()->getModulesFor( $activeComponent ) as $module ) {
 				$parser->getOutput()->addModuleStyles( [ $module ] );
+				$parser->getOutput()->addModules( [ $module ] );
 			}
 		}
 		return true;

--- a/tests/phpunit/Unit/HooksHandlerTest.php
+++ b/tests/phpunit/Unit/HooksHandlerTest.php
@@ -6,6 +6,8 @@ use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\HooksHandler;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
+use Parser;
+use ParserOutput;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -71,5 +73,51 @@ class HooksHandlerTest extends TestCase {
 	 */
 	public function testOnOutputPageParserOutput() {
 		$this->assertTrue( true );
+	}
+
+	public function testOnParserAfterParseLoadsActiveComponentScriptsAndStyles() {
+		$loadedStyles = [];
+		$loadedModules = [];
+
+		$parserOutput = $this->createMock( ParserOutput::class );
+		$parserOutput->method( 'addModuleStyles' )
+			->willReturnCallback( function ( $m ) use ( &$loadedStyles ) {
+				$loadedStyles = array_merge( $loadedStyles, (array)$m );
+			} );
+		$parserOutput->method( 'addModules' )
+			->willReturnCallback( function ( $m ) use ( &$loadedModules ) {
+				$loadedModules = array_merge( $loadedModules, (array)$m );
+			} );
+
+		$parser = $this->createMock( Parser::class );
+		$parser->method( 'getOutput' )->willReturn( $parserOutput );
+
+		$service = $this->createMock( BootstrapComponentsService::class );
+		$service->method( 'getNameOfActiveSkin' )->willReturn( 'vector' );
+		$service->method( 'getActiveComponents' )->willReturn( [ 'tooltip', 'popover' ] );
+
+		$library = $this->createMock( ComponentLibrary::class );
+		$library->method( 'isRegistered' )->willReturn( true );
+		$library->method( 'getModulesFor' )
+			->willReturnCallback( function ( $name ) {
+				return [ 'ext.bootstrapComponents.' . $name . '.fix' ];
+			} );
+
+		$handler = new HooksHandler(
+			$service,
+			$library,
+			$this->createMock( NestingController::class )
+		);
+
+		$text = '';
+		$handler->onParserAfterParse( $parser, $text, null );
+
+		// Per-component fix modules must reach BOTH addModuleStyles and addModules
+		// (style-only modules treat addModules as a no-op; modules with a scripts
+		// entry get their JS init via that call).
+		$this->assertContains( 'ext.bootstrapComponents.tooltip.fix', $loadedStyles );
+		$this->assertContains( 'ext.bootstrapComponents.popover.fix', $loadedStyles );
+		$this->assertContains( 'ext.bootstrapComponents.tooltip.fix', $loadedModules );
+		$this->assertContains( 'ext.bootstrapComponents.popover.fix', $loadedModules );
 	}
 }


### PR DESCRIPTION
Closes #68.

Restores BC's intended sparse-loading scheme by closing the two gaps that broke it. **+5 lines** across 2 source files.

## Root cause

BC was designed to load each component's `.fix` ResourceLoader module **only on pages that actually use that component** — sparse, on-demand loading. The mechanism: each component calls `BootstrapComponentsService::registerComponentAsActive($name)` when used, and `HooksHandler::onParserAfterParse` iterates the registered set to queue the per-component modules. Two gaps broke that scheme:

1. **Only `ImageModal::177` called `registerComponentAsActive()`.** The 11 explicit-syntax components (Accordion, Alert, Badge, Button, Card, Carousel, Collapse, Jumbotron, Modal, Popover, Tooltip) never registered themselves, so the foreach never iterated over them — their `.fix` modules were never queued, CSS or JS. ImageModal was the only one that worked.
2. **The foreach only called `$parserOutput->addModuleStyles()` (CSS only).** Modules with a `scripts:` entry (`tooltip.fix`, `popover.fix`, `carousel.fix`) never had their JS half loaded — `addModuleStyles` doesn't cover that.

## Fix

Two one-line additions, at the right architectural layer in each case:

- **`AbstractComponent::parseComponent()`** now calls `registerComponentAsActive($this->getComponentName())` right after `$nestingController->open($this)`. All 11 explicit-syntax components inherit this via the single chokepoint. The service is fetched via `MediaWikiServices::getInstance()->getService(...)`, matching the service-locator pattern already used by `LuaLibrary`, `CarouselGallery`, and `ImageModal` in the codebase.
- **`HooksHandler::onParserAfterParse` foreach** now calls both `addModuleStyles([$module])` and `addModules([$module])`. Style-only modules treat the latter as a no-op; modules with a `scripts:` entry get their JS init loaded.

## Scope

- 2 source files (`AbstractComponent.php`, `HooksHandler.php`), **+5 lines / -0**
- 1 test file (`HooksHandlerTest.php`), **+59 lines / -0** — new unit test pinning the foreach `addModules` contract
- No constructor changes — uses the existing service-locator pattern

## Verification

Tested on **MW 1.43.8 + Chameleon BS4** (where the bug manifests) and on the oldest supported floor **MW 1.39.17** + Vector:

|                       | Sparse loading working? | Interactions firing? |
|---|---|---|
| **MW 1.43.8** + Chameleon BS4 — `TooltipPopoverTest` page | `tooltip.fix` + `popover.fix` = `ready` ✓; `carousel.fix` = `registered` (not loaded — sparse!) ✓ | tooltip popup ✓; popover popup ✓ |
| **MW 1.43.8** + Chameleon BS4 — `ModalTest` page | `modal.fix` = `ready` ✓; tooltip / popover / carousel `.fix` all stay `registered` (no triggers on this page) ✓ | modal opens (`.show`, backdrop, `body.modal-open`) ✓ |
| **MW 1.39.17** + Vector — `TooltipPopoverTest` page | same shape as 1.43.8 row 1 ✓ | same ✓ |
| **MW 1.39.17** + Chameleon BS4 — `TooltipPopoverTest` page | same shape ✓ | same ✓ |
| **MW 1.39.17** + Medik — `TooltipPopoverTest` page | same shape ✓ | same ✓ |

Visual confirmation of the interactions:

|                                       | Tooltip hover                                                              | Popover click                                                              |
|---------------------------------------|----------------------------------------------------------------------------|----------------------------------------------------------------------------|
| **MW 1.43.8** + Chameleon BS4         | <img width="1920" height="1080" alt="sub68-mw143-tooltip-hover" src="https://github.com/user-attachments/assets/f115b6bc-fa9b-455e-8078-7368d13763bc" />                                | <img width="1920" height="1080" alt="sub68-mw143-popover-click" src="https://github.com/user-attachments/assets/bece97e8-e819-4a01-bf3b-7e5f0a37f267" />                                |
| **MW 1.39.17** + Vector               | <img width="1920" height="1080" alt="sub68-mw139-tooltip-hover" src="https://github.com/user-attachments/assets/5ea5180c-0eb4-419b-8410-a051510be50c" />                                | <img width="1920" height="1080" alt="sub68-mw139-popover-click" src="https://github.com/user-attachments/assets/1ac12e50-4800-4934-af33-0b38a4d79b9d" />                                |
| **MW 1.39.17** + Chameleon BS4        | <img width="1920" height="1080" alt="sub68-mw139-chameleon-tooltip" src="https://github.com/user-attachments/assets/bd6ebc76-b866-4e05-a894-a7532795b939" />                            | <img width="1920" height="1080" alt="sub68-mw139-chameleon-popover" src="https://github.com/user-attachments/assets/d0e71cda-0b4c-4441-ad05-ea0393a7911b" />                            |
| **MW 1.39.17** + Medik                | <img width="1920" height="1080" alt="sub68-mw139-medik-tooltip" src="https://github.com/user-attachments/assets/aa726d4e-d31e-49f6-afe5-89a8979ab071" />                                | <img width="1920" height="1080" alt="sub68-mw139-medik-popover" src="https://github.com/user-attachments/assets/82117e1a-a530-41b4-817d-d9aecdcac1bb" />                                |

The sparse-load assertion is the key new evidence: on a tooltip-only page, only `tooltip.fix` + `popover.fix` load. On a modal-only page, only `modal.fix` loads. On a page with nothing, no BC init modules load. Original design intent restored.

## Tests

New: `HooksHandlerTest::testOnParserAfterParseLoadsActiveComponentScriptsAndStyles` asserts that the foreach calls both `addModuleStyles` AND `addModules` per active component'"'"'s module — pins the contract this PR restores against future regressions.

PHPUnit (`--group mediawiki-databaseless`) on MW 1.39: **339 tests, 537 assertions, 6 failures** — baseline plus one new test, no new failures (same 6 pre-existing `BootstrapComponentsServiceTest` / `ImageModalTriggerTest` / `ImageModalTest` failures, all unrelated to the module-loading path).




