### PR TITLE
Prepare release 5.2.3

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,15 @@
 ## Release Notes
 
+### BootstrapComponents 5.2.3
+
+Released on 21-May-2026
+
+Changes:
+* add translations via translatewiki
+
+Fixes:
+* fix modal, tooltip, and popover not appearing on MediaWiki 1.43+
+
 ### BootstrapComponents 5.2.2
 
 Released on 01-April-2026

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "BootstrapComponents",
-	"version": "5.2.2",
+	"version": "5.2.3",
 	"author": [ "Tobias Oetterer" ],
 	"url": "https://www.mediawiki.org/wiki/Extension:BootstrapComponents",
 	"descriptionmsg": "bootstrap-components-desc",


### PR DESCRIPTION
Prepares the 5.2.3 patch release. Two commits matching the 5.2.2 release-prep pattern:

1. **Update release notes** — add the 5.2.3 entry covering everything merged since 5.2.2:
   - `add translations via translatewiki` (covers `0f82003` + `d681827`)
   - `fix modal trigger not opening modals on MediaWiki 1.43+` (PR #75)
   - `restore sparse per-component module loading so tooltip and popover JavaScript initialise correctly` (PR #80)
2. **Bump version** — `extension.json` `5.2.2` → `5.2.3`

`Released on _TBD_` is intentional — fill in the actual date at tag time.

No code changes, no test changes — purely the release-prep metadata. Once merged, tag `5.2.3` from the merge commit.

Closes #68 once tagged (already addressed by PR #75 + PR #80; the issue references all three sub-bugs of #68 and this is the release that ships the fixes).