### PR TITLE
Modernise the extension under a MediaWiki 1.43 baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,32 +13,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_39'
-            php: 8.0
-            type: coverage
-            experimental: false
-          - mw: 'REL1_39'
+          - mw: 'REL1_43'
             php: 8.1
             type: normal
             experimental: false
-          - mw: 'REL1_40'
-            php: 8.1
-            type: normal
-            experimental: false
-          - mw: 'REL1_41'
-            php: 8.1
-            type: normal
-            experimental: false
-          - mw: 'REL1_42'
+          - mw: 'REL1_44'
             php: 8.2
             type: normal
             experimental: false
-          - mw: 'REL1_43'
+          - mw: 'REL1_45'
             php: 8.3
+            type: normal
+            experimental: false
+          - mw: 'master'
+            php: 8.4
             type: normal
             experimental: true
           - mw: 'master'
-            php: 8.4
+            php: 8.5
             type: normal
             experimental: true
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,8 +14,9 @@ tools:
     php_loc: true
     php_analyzer: true
     sensiolabs_security_checker: true
-    external_code_coverage:
-        timeout: '1200' # timeout in seconds
+    # TODO: Scrutinizer Ocular coverage disabled due to https://github.com/scrutinizer-ci/ocular/issues/51
+    # external_code_coverage:
+    #    timeout: '1200' # timeout in seconds
 
 checks:
     php:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ configuration it can add a new [gallery][Gallery] mode, and replace normal
 [image rendering][Image] with an image modal.
 
 ## Requirements
-* PHP 8.0 or later
-* MediaWiki 1.39 or later
+* PHP 8.1 or later
+* MediaWiki 1.43 or later
 
 ## Documentation
 - [Installation and configuration](docs/installation-configuration.md)

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,15 @@
 		"source": "https://github.com/oetterer/BootstrapComponents"
 	},
 	"require": {
-		"php": ">=8.0",
+		"php": ">=8.1",
 		"composer/installers": "^2|^1.0.1",
 		"mediawiki/bootstrap": "^5.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "46.0.0",
-    "mediawiki/mediawiki-phan-config": "0.15.1",
+		"mediawiki/mediawiki-phan-config": "0.15.1",
 		"phpmd/phpmd": "~2.1",
-		"php": ">=8.0"
+		"php": ">=8.1"
 	},
 	"suggest": {
 		"mediawiki/scribunto": "Framework for embedding scripting languages into MediaWiki pages"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,13 @@
 ## Release Notes
 
+### BootstrapComponents 6.0.0
+
+Released on TBD
+
+Breaking changes:
+* requires MediaWiki 1.43 or later
+* requires PHP 8.1 or later
+
 ### BootstrapComponents 5.2.3
 
 Released on 21-May-2026

--- a/extension.json
+++ b/extension.json
@@ -7,7 +7,7 @@
 	"license-name": "GPL-3.0-or-later",
 	"type": "parserhook",
 	"requires": {
-		"MediaWiki": ">= 1.39.0"
+		"MediaWiki": ">= 1.43.0"
 	},
 	"ConfigRegistry": {
 		"BootstrapComponents": "GlobalVarConfig::newInstance"

--- a/src/AbstractComponent.php
+++ b/src/AbstractComponent.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents;
 
 use MediaWiki\MediaWikiServices;
-use MWException;
+use RuntimeException;
 
 /**
  * Class AbstractComponent
@@ -107,7 +107,7 @@ abstract class AbstractComponent implements NestableInterface {
 	 * @param ParserOutputHelper $parserOutputHelper
 	 * @param NestingController  $nestingController
 	 *
-	 * @throws MWException cascading {@see ComponentLibrary::getNameFor} or {@see Component::extractAttribute}
+	 * @throws RuntimeException cascading {@see ComponentLibrary::getNameFor} or {@see Component::extractAttribute}
 	 */
 	public function __construct( $componentLibrary, $parserOutputHelper, $nestingController ) {
 		$this->componentLibrary = $componentLibrary;
@@ -144,14 +144,14 @@ abstract class AbstractComponent implements NestableInterface {
 	/**
 	 * @param ParserRequest $parserRequest ;
 	 *
-	 * @throws MWException self or cascading from {@see Component::processArguments}
+	 * @throws RuntimeException self or cascading from {@see Component::processArguments}
 	 *                      or {@see NestingController::close}
 	 *
 	 * @return string|array
 	 */
 	public function parseComponent( $parserRequest ) {
 		if ( !is_a( $parserRequest, ParserRequest::class ) ) {
-			throw new MWException( 'Invalid ParserRequest supplied to component ' . $this->getComponentName() . '!' );
+			throw new RuntimeException( 'Invalid ParserRequest supplied to component ' . $this->getComponentName() . '!' );
 		}
 		$this->getNestingController()->open( $this );
 		MediaWikiServices::getInstance()

--- a/src/AbstractComponent.php
+++ b/src/AbstractComponent.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents;
 
 use MediaWiki\MediaWikiServices;
-use \MWException;
+use MWException;
 
 /**
  * Class AbstractComponent

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -104,19 +104,16 @@ class ApplicationFactory {
 	}
 
 	/**
-	 * @param string             $id
-	 * @param string             $trigger must be safe raw html (best run through {@see Parser::recursiveTagParse})
-	 * @param string             $content must be safe raw html (best run through {@see Parser::recursiveTagParse})
-	 * @param ParserOutputHelper $parserOutputHelper @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
+	 * @param string $id
+	 * @param string $trigger must be safe raw html (best run through {@see Parser::recursiveTagParse})
+	 * @param string $content must be safe raw html (best run through {@see Parser::recursiveTagParse})
 	 *
 	 * @see ModalBuilder::__construct
 	 *
 	 * @return ModalBuilder
 	 */
-	public function getNewModalBuilder(
-		string $id, string $trigger, string $content, ParserOutputHelper $parserOutputHelper
-	): ModalBuilder {
-		return new ModalBuilder( $id, $trigger, $content, $parserOutputHelper );
+	public function getNewModalBuilder( string $id, string $trigger, string $content ): ModalBuilder {
+		return new ModalBuilder( $id, $trigger, $content );
 	}
 
 	/**

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -28,7 +28,7 @@ namespace MediaWiki\Extension\BootstrapComponents;
 
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
-use MWException;
+use RuntimeException;
 use ReflectionClass;
 
 /**
@@ -126,7 +126,7 @@ class ApplicationFactory {
 	 *
 	 * @see ParserRequest::__construct
 	 *
-	 * @throws \MWException cascading {@see ParserRequest::__construct}
+	 * @throws RuntimeException cascading {@see ParserRequest::__construct}
 	 *
 	 * @return ParserRequest
 	 */
@@ -141,7 +141,7 @@ class ApplicationFactory {
 	 *
 	 * @see ParserOutputHelper
 	 *
-	 * @throws MWException  cascading {@see ApplicationFactory::getApplication}
+	 * @throws RuntimeException  cascading {@see ApplicationFactory::getApplication}
 	 *
 	 * @return ParserOutputHelper
 	 */
@@ -158,7 +158,7 @@ class ApplicationFactory {
 	 * @param string $name
 	 * @param string $class
 	 *
-	 * @throws MWException when class to register does not exist
+	 * @throws RuntimeException when class to register does not exist
 	 *
 	 * @return bool
 	 */
@@ -169,7 +169,7 @@ class ApplicationFactory {
 			$this->applicationClassRegister[$application] = $applicationClass;
 			return true;
 		} elseif ( $application != '' ) {
-			throw new MWException( 'ApplicationFactory was requested to register non existing class "' . $applicationClass . '"!' );
+			throw new RuntimeException( 'ApplicationFactory was requested to register non existing class "' . $applicationClass . '"!' );
 		}
 		$this->getLogger()->error( 'ApplicationFactory was requested to register invalid application for class ' . $applicationClass . '!' );
 		return false;
@@ -200,7 +200,7 @@ class ApplicationFactory {
 	 *
 	 * @param string $name
 	 *
-	 * @throws MWException  when no class is registered for the requested application or the creation of the object fails.
+	 * @throws RuntimeException  when no class is registered for the requested application or the creation of the object fails.
 	 *
 	 * @return object
 	 */
@@ -209,7 +209,7 @@ class ApplicationFactory {
 			return $this->applicationStore[$name];
 		}
 		if ( !isset( $this->applicationClassRegister[$name] ) ) {
-			throw new MWException( 'ApplicationFactory was requested to return application "' . $name . '". No appropriate class registered!' );
+			throw new RuntimeException( 'ApplicationFactory was requested to return application "' . $name . '". No appropriate class registered!' );
 		}
 		$args = func_get_args();
 		array_shift( $args ); # because, we already used the first argument $name
@@ -217,7 +217,7 @@ class ApplicationFactory {
 		try {
 			$objectReflection = new ReflectionClass( $this->applicationClassRegister[$name] );
 		} catch ( \ReflectionException $e ) {
-			throw new MWException(
+			throw new RuntimeException(
 				'Error while trying to build application "' . $name . '" with class ' . $this->applicationClassRegister[$name]
 			);
 		}

--- a/src/BootstrapComponents.php
+++ b/src/BootstrapComponents.php
@@ -86,12 +86,6 @@ class BootstrapComponents {
 			throw new MWException( 'This file is part of a Mediawiki Extension, it is not a valid entry point.' );
 		}
 
-		if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.39', 'lt' ) ) {
-			echo '<b>Error:</b> <a href="https://github.com/oetterer/BootstrapComponents/">Bootstrap Components</a> '
-				. 'is only compatible with MediaWiki 1.39 or above. You need to upgrade MediaWiki first.' . PHP_EOL;
-			throw new MWException( 'BootstrapComponents detected an incompatible MediaWiki version. Exiting.' );
-		}
-
 		// Using the constant as indicator to avoid class_exists
 		if ( !\ExtensionRegistry::getInstance()->isLoaded('Bootstrap') ) {
 			if ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) {

--- a/src/BootstrapComponents.php
+++ b/src/BootstrapComponents.php
@@ -44,7 +44,7 @@
 namespace MediaWiki\Extension\BootstrapComponents;
 
 use Exception;
-use MWException;
+use RuntimeException;
 
 /**
  * Provides methods to register, when installed by composer
@@ -83,7 +83,7 @@ class BootstrapComponents {
 
 		if ( !defined( 'MEDIAWIKI' ) ) {
 			echo 'This file is part of the Mediawiki extension BootstrapComponents, it is not a valid entry point.' . PHP_EOL;
-			throw new MWException( 'This file is part of a Mediawiki Extension, it is not a valid entry point.' );
+			throw new RuntimeException( 'This file is part of a Mediawiki Extension, it is not a valid entry point.' );
 		}
 
 		// Using the constant as indicator to avoid class_exists

--- a/src/BootstrapComponents.php
+++ b/src/BootstrapComponents.php
@@ -55,9 +55,6 @@ use RuntimeException;
  */
 class BootstrapComponents {
 
-	const EXTENSION_DATA_NO_IMAGE_MODAL = 'bsc_no_image_modal';
-
-
 	/**
 	 * @var string $version
 	 */

--- a/src/BootstrapComponents.php
+++ b/src/BootstrapComponents.php
@@ -43,7 +43,6 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use ConfigException;
 use Exception;
 use MWException;
 

--- a/src/BootstrapComponentsService.php
+++ b/src/BootstrapComponentsService.php
@@ -2,8 +2,8 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use Config;
-use RequestContext;
+use MediaWiki\Config\Config;
+use MediaWiki\Context\RequestContext;
 
 class BootstrapComponentsService
 {

--- a/src/CarouselGallery.php
+++ b/src/CarouselGallery.php
@@ -43,7 +43,7 @@ class CarouselGallery extends ImageGalleryBase {
 	 *
 	 * @param ParserOutputHelper $parserOutputHelper used for unit tests
 	 *
-	 * @throws \MWException cascading {@see CarouselGallery::constructCarouselParserRequest} and  {@see AbstractComponent::parseComponent}
+	 * @throws RuntimeException cascading {@see CarouselGallery::constructCarouselParserRequest} and  {@see AbstractComponent::parseComponent}
 	 * @return string
 	 */
 	public function toHTML( $parserOutputHelper = null ) {
@@ -160,7 +160,7 @@ class CarouselGallery extends ImageGalleryBase {
 	 * From array of supplies images and some other object properties, this constructs a parser request object,
 	 * to be used in the carousel component.
 	 *
-	 * @throws \MWException cascading {@see ApplicationFactory::getNewParserRequest}
+	 * @throws RuntimeException cascading {@see ApplicationFactory::getNewParserRequest}
 	 *
 	 * @return false|ParserRequest  returns false, if no valid images were detected
 	 */

--- a/src/CarouselGallery.php
+++ b/src/CarouselGallery.php
@@ -26,10 +26,10 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use MediaWiki\Extension\BootstrapComponents\Components\Carousel;
 use ImageGalleryBase;
+use MediaWiki\Extension\BootstrapComponents\Components\Carousel;
 use MediaWiki\MediaWikiServices;
-use Title;
+use MediaWiki\Title\Title;
 
 /**
  * Class CarouselGallery

--- a/src/ComponentLibrary.php
+++ b/src/ComponentLibrary.php
@@ -26,8 +26,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use MediaWiki\MediaWikiServices;
-use \MWException;
+use MWException;
 
 /**
  * Class ComponentLibrary

--- a/src/ComponentLibrary.php
+++ b/src/ComponentLibrary.php
@@ -26,7 +26,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use MWException;
+use RuntimeException;
 
 /**
  * Class ComponentLibrary
@@ -136,7 +136,7 @@ class ComponentLibrary {
 	 * @param string $componentIdentifier
 	 *
 	 * @return array
-	 * @throws MWException provided component is not known
+	 * @throws RuntimeException provided component is not known
 	 */
 	public function getAliasesFor( string $componentIdentifier ): array {
 		return $this->accessComponentDataStore( $componentIdentifier, 'aliases' );
@@ -148,7 +148,7 @@ class ComponentLibrary {
 	 * @param string $componentIdentifier
 	 *
 	 * @return array
-	 * @throws MWException provided component is not known
+	 * @throws RuntimeException provided component is not known
 	 */
 	public function getAttributesFor( string $componentIdentifier ): array {
 		return $this->accessComponentDataStore( $componentIdentifier, 'attributes' );
@@ -160,7 +160,7 @@ class ComponentLibrary {
 	 * @param string $componentIdentifier
 	 *
 	 * @return string
-	 * @throws MWException provided component is not known
+	 * @throws RuntimeException provided component is not known
 	 */
 	public function getClassFor( string $componentIdentifier ): string {
 		return $this->accessComponentDataStore( $componentIdentifier, 'class' );
@@ -180,7 +180,7 @@ class ComponentLibrary {
 	public function getHandlerTypeFor( string $componentIdentifier ): string {
 		try {
 			return $this->accessComponentDataStore( $componentIdentifier, 'handlerType' );
-		} catch ( MWException $e ) {
+		} catch ( RuntimeException $e ) {
 			return 'UNKNOWN';
 		}
 	}
@@ -205,7 +205,7 @@ class ComponentLibrary {
 	 */
 	public function getModulesFor( string $componentIdentifier, ?string $skin = null ): array {
 		if ( !$this->isKnown( $componentIdentifier ) ) {
-			// this prevents us from running into a MWException in the next call.
+			// this prevents us from running into a RuntimeException in the next call.
 			return [];
 		}
 		$allModules = $this->accessComponentDataStore( $componentIdentifier, 'modules' );
@@ -227,7 +227,7 @@ class ComponentLibrary {
 	 *
 	 * @param string $componentClass
 	 *
-	 * @throws MWException if supplied class is not registered
+	 * @throws RuntimeException if supplied class is not registered
 	 *
 	 * @return string
 	 */
@@ -241,7 +241,7 @@ class ComponentLibrary {
 			}
 		}
 		if ( is_null( $component ) ) {
-			throw new MWException( 'Trying to get a component name for unregistered class "' . (string) $componentClass . '"!' );
+			throw new RuntimeException( 'Trying to get a component name for unregistered class "' . (string) $componentClass . '"!' );
 		}
 		return $this->accessComponentDataStore( $component, 'name' );
 	}
@@ -301,13 +301,13 @@ class ComponentLibrary {
 	 * @param string $componentIdentifier
 	 * @param string $field
 	 *
-	 * @throws MWException on non-existing $componentIdentifier or $field
+	 * @throws RuntimeException on non-existing $componentIdentifier or $field
 	 *
 	 * @return mixed
 	 */
 	protected function accessComponentDataStore( string $componentIdentifier, string $field ): mixed {
 		if ( !isset( $this->getComponentDataStore()[$componentIdentifier][$field] ) ) {
-			throw new MWException(
+			throw new RuntimeException(
 				'Trying to access undefined field \'' . $field . '\' of component \'' . $componentIdentifier . '\'. Aborting'
 			);
 		}

--- a/src/Components/Accordion.php
+++ b/src/Components/Accordion.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Accordion

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Alert

--- a/src/Components/Badge.php
+++ b/src/Components/Badge.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Badge

--- a/src/Components/Button.php
+++ b/src/Components/Button.php
@@ -27,8 +27,8 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
-use \Title;
+use MediaWiki\Html\Html;
+use MediaWiki\Title\Title;
 
 /**
  * Class Button

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -26,12 +26,12 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
-use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
+use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
-use \Html;
-use \MWException;
+use MediaWiki\Html\Html;
+use MWException;
 
 /**
  * Class Card

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -31,7 +31,7 @@ use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
 use MediaWiki\Html\Html;
-use MWException;
+use RuntimeException;
 
 /**
  * Class Card
@@ -64,7 +64,7 @@ class Card extends AbstractComponent {
 	 * @param ParserOutputHelper $parserOutputHelper
 	 * @param NestingController  $nestingController
 	 *
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function __construct( $componentLibrary, $parserOutputHelper, $nestingController ) {
 		parent::__construct( $componentLibrary, $parserOutputHelper, $nestingController );

--- a/src/Components/Carousel.php
+++ b/src/Components/Carousel.php
@@ -28,7 +28,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
 use MediaWiki\Extension\BootstrapComponents\ParserRequest;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Carousel

--- a/src/Components/Collapse.php
+++ b/src/Components/Collapse.php
@@ -26,11 +26,11 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
-use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
+use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
 use MediaWiki\Extension\BootstrapComponents\ParserRequest;
-use \Html;
-use \MWException;
+use MediaWiki\Html\Html;
+use MWException;
 
 /**
  * Class Collapse

--- a/src/Components/Collapse.php
+++ b/src/Components/Collapse.php
@@ -30,7 +30,7 @@ use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
 use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
 use MediaWiki\Extension\BootstrapComponents\ParserRequest;
 use MediaWiki\Html\Html;
-use MWException;
+use RuntimeException;
 
 /**
  * Class Collapse
@@ -69,7 +69,7 @@ class Collapse extends AbstractComponent {
 	 *
 	 * @param ParserRequest $parserRequest
 	 *
-	 * @throws MWException cascading {@see \BootstrapComponents\Component::parseComponent}
+	 * @throws RuntimeException cascading {@see \BootstrapComponents\Component::parseComponent}
 	 * @return string
 	 */
 	private function generateButton( ParserRequest $parserRequest ) {

--- a/src/Components/Jumbotron.php
+++ b/src/Components/Jumbotron.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Jumbotron

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -63,8 +63,7 @@ class Modal extends AbstractComponent {
 		$modal = ApplicationFactory::getInstance()->getNewModalBuilder(
 			$this->getId(),
 			$text,
-			$safeInput,
-			$this->getParserOutputHelper()
+			$safeInput
 		);
 		return $modal->setOuterClass(
 			$this->arrayToString( $outerClass, ' ' )

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -29,7 +29,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Components;
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
 use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
 use MediaWiki\Extension\BootstrapComponents\ModalBuilder;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Modal

--- a/src/Components/Popover.php
+++ b/src/Components/Popover.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Popover

--- a/src/Components/Tooltip.php
+++ b/src/Components/Tooltip.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Components;
 
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
-use \Html;
+use MediaWiki\Html\Html;
 
 /**
  * Class Tooltip

--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -28,7 +28,6 @@ namespace MediaWiki\Extension\BootstrapComponents\Hooks;
 
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Output\OutputPage;
-use MediaWiki\Parser\ParserOutput;
 
 /**
  * Class OutputPageParserOutput
@@ -52,31 +51,18 @@ class OutputPageParserOutput {
 	private OutputPage $outputPage;
 
 	/**
-	 * @var ParserOutput $parserOutput
-	 *
-	 * @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
-	 */
-	private ParserOutput $parserOutput;
-
-	/**
-	 * OutputPageParserOutput constructor.
-	 *
 	 * @param OutputPage $outputPage
-	 * @param ParserOutput $parserOutput @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
 	 * @param BootstrapComponentsService $service
 	 */
-	public function __construct(
-		OutputPage &$outputPage, ParserOutput $parserOutput, BootstrapComponentsService $service
-	) {
+	public function __construct( OutputPage &$outputPage, BootstrapComponentsService $service ) {
 		$this->outputPage = $outputPage;
-		$this->parserOutput = $parserOutput;
 		$this->bootstrapComponentService = $service;
 	}
 
 	/**
 	 * @return void
 	 */
-	public function process(): void	{
+	public function process(): void {
 		if ( $this->getBootstrapComponentsService()->vectorSkinInUse() ) {
 			$this->getOutputPage()->addModules( [ 'ext.bootstrapComponents.vector-fix' ] );
 		}
@@ -91,14 +77,5 @@ class OutputPageParserOutput {
 	 */
 	protected function getOutputPage(): OutputPage {
 		return $this->outputPage;
-	}
-
-	/**
-	 * @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
-	 *
-	 * @return ParserOutput
-	 */
-	protected function getParserOutput(): ParserOutput {
-		return $this->parserOutput;
 	}
 }

--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -27,13 +27,8 @@
 namespace MediaWiki\Extension\BootstrapComponents\Hooks;
 
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
-/*
- * TODO switch to these, wehen we drop support for mw < 1.40
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\ParserOutput;
- */
-use \OutputPage;
-use \ParserOutput;
 
 /**
  * Class OutputPageParserOutput

--- a/src/Hooks/ParserFirstCallInit.php
+++ b/src/Hooks/ParserFirstCallInit.php
@@ -72,7 +72,7 @@ class ParserFirstCallInit {
 	 * @param ComponentLibrary  $componentLibrary
 	 * @param NestingController $nestingController
 	 *
-	 * @throws \MWException  cascading {@see \BootstrapComponents\ApplicationFactory::getParserOutputHelper}
+	 * @throws RuntimeException  cascading {@see \BootstrapComponents\ApplicationFactory::getParserOutputHelper}
 	 */
 	public function __construct( $parser, $componentLibrary, $nestingController ) {
 		$this->componentLibrary = $componentLibrary;
@@ -82,7 +82,7 @@ class ParserFirstCallInit {
 	}
 
 	/**
-	 * @throws \MWException  cascading {@see \Parser::setFunctionHook} and {@see Parser::setHook}
+	 * @throws RuntimeException  cascading {@see \Parser::setFunctionHook} and {@see Parser::setHook}
 	 *
 	 * @return bool
 	 */

--- a/src/Hooks/ParserFirstCallInit.php
+++ b/src/Hooks/ParserFirstCallInit.php
@@ -31,7 +31,7 @@ use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
-use Parser;
+use MediaWiki\Parser\Parser;
 use ReflectionClass;
 
 /**

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -48,22 +48,22 @@ class HooksHandler implements
 	/**
 	 * @var Config
 	 */
-	var Config $config;
+	private Config $config;
 
 	/**
 	 * @var BootstrapComponentsService
 	 */
-	var BootstrapComponentsService $bootstrapComponentsService;
+	private BootstrapComponentsService $bootstrapComponentsService;
 
 	/**
 	 * @var ComponentLibrary
 	 */
-	var ComponentLibrary $componentLibrary;
+	private ComponentLibrary $componentLibrary;
 
 	/**
 	 * @var NestingController
 	 */
-	var NestingController $nestingController;
+	private NestingController $nestingController;
 
 	public function __construct(
 		BootstrapComponentsService $bootstrapComponentsService, ComponentLibrary $componentLibrary,

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -193,8 +193,7 @@ class HooksHandler implements
 	public function onOutputPageParserOutput( $outputPage, $parserOutput ): void {
 		// @todo check, if we need to omit execution on actions edit, submit, or history
 		// $action = $outputPage->parserOptions()->getUser()->getRequest()->getVal( "action" );
-		$hook =
-			new OutputPageParserOutput( $outputPage, $parserOutput, $this->getBootstrapComponentsService() );
+		$hook = new OutputPageParserOutput( $outputPage, $this->getBootstrapComponentsService() );
 
 		$hook->process();
 	}

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -131,7 +131,7 @@ class HooksHandler implements
 	 * @param Parser $parser
 	 * @param string &$query
 	 * @param null|int &$widthOption
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function onImageBeforeProduceHTML(
 		$linker, &$title, &$file, &$frameParams, &$handlerParams, &$time, &$res, $parser, &$query, &$widthOption
@@ -242,7 +242,7 @@ class HooksHandler implements
 	 * @param Parser $parser
 	 *
 	 * @return bool
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function onParserFirstCallInit( $parser ): bool {
 		$hook = new ParserFirstCallInit( $parser, $this->getComponentLibrary(), $this->getNestingController() );

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -3,7 +3,7 @@
 namespace MediaWiki\Extension\BootstrapComponents;
 
 use Bootstrap\BootstrapManager;
-use Config;
+use MediaWiki\Config\Config;
 use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
 use MediaWiki\Extension\BootstrapComponents\Hooks\ParserFirstCallInit;
 use MediaWiki\Hook\GalleryGetModesHook;
@@ -14,9 +14,7 @@ use MediaWiki\Hook\ParserAfterParseHook;
 use MediaWiki\Hook\ParserFirstCallInitHook;
 use MediaWiki\Hook\SetupAfterCacheHook;
 use MediaWiki\MediaWikiServices;
-use Parser;
-// TODO switch to then when dropping support for mw < 1.40
-// use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\Parser;
 use SMW\Utils\File;
 use StripState;
 

--- a/src/ImageModal.php
+++ b/src/ImageModal.php
@@ -31,7 +31,7 @@ use MediaTransformOutput;
 use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
-use MWException;
+use RuntimeException;
 
 /**
  * Class ImageModal
@@ -98,7 +98,7 @@ class ImageModal implements NestableInterface {
 	 * @param BootstrapComponentsService $bootstrapComponentService
 	 * @param ParserOutputHelper|null $parserOutputHelper DI for unit testing
 	 *
-	 * @throws MWException cascading {@see ApplicationFactory} methods
+	 * @throws RuntimeException cascading {@see ApplicationFactory} methods
 	 */
 	public function __construct(
 		$null, Title $title, File $file,
@@ -162,7 +162,7 @@ class ImageModal implements NestableInterface {
 	 * @param string|bool $time          Timestamp of the file, set as false for current
 	 * @param string      $res           Final HTML output, used if this returns false
 	 *
-	 * @throws MWException     cascading {@see NestingController::open}
+	 * @throws RuntimeException     cascading {@see NestingController::open}
 	 * @throws \ConfigException cascading {@see ImageModal::generateTrigger}
 	 *
 	 * @return bool

--- a/src/ImageModal.php
+++ b/src/ImageModal.php
@@ -345,8 +345,7 @@ class ImageModal implements NestableInterface {
 		$modal = ApplicationFactory::getInstance()->getNewModalBuilder(
 			$this->getId(),
 			$triggerString,
-			$content,
-			$this->getParserOutputHelper()
+			$content
 		);
 		$modal->setHeader(
 			$this->getTitle()->getBaseText()

--- a/src/ImageModal.php
+++ b/src/ImageModal.php
@@ -27,11 +27,11 @@
 namespace MediaWiki\Extension\BootstrapComponents;
 
 use File;
-use Html;
 use MediaTransformOutput;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use MWException;
-use Title;
 
 /**
  * Class ImageModal

--- a/src/ImageModalTrigger.php
+++ b/src/ImageModalTrigger.php
@@ -26,15 +26,14 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use Config;
-use ConfigException;
+use MediaWiki\Config\Config;
+use MediaWiki\Config\ConfigException;
 use Exception;
-use \Linker;
-use \Html;
-use \MediaWiki\MediaWikiServices;
-use MediaWiki\User\UserOptionsLookup;
-use \RequestContext;
-use \Title;
+use MediaWiki\Html\Html;
+use MediaWiki\Linker\Linker;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+use MediaWiki\Context\RequestContext;
 
 /**
  * Class ImageModal

--- a/src/LuaLibrary.php
+++ b/src/LuaLibrary.php
@@ -29,7 +29,7 @@ namespace MediaWiki\Extension\BootstrapComponents;
 use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
 use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LuaEngine;
 use MediaWiki\MediaWikiServices;
-use MWException;
+use RuntimeException;
 use ReflectionClass;
 use ReflectionException;
 
@@ -84,7 +84,7 @@ class LuaLibrary extends LibraryBase {
 	 * @return string[]
 	 *
 	 * Note: Please refrain from using Type hints in function signature. Will break tests!
-	 *@throws MWException
+	 *@throws RuntimeException
 	 *
 	 * @throws ReflectionException
 	 */
@@ -125,7 +125,7 @@ class LuaLibrary extends LibraryBase {
 	 * @param null|string $component
 	 *
 	 * @return ParserRequest
-	 *@throws MWException
+	 *@throws RuntimeException
 	 *
 	 */
 	protected function buildParserRequest(
@@ -142,7 +142,7 @@ class LuaLibrary extends LibraryBase {
 	/**
 	 * @param string $componentClass
 	 *
-	 * @throws MWException
+	 * @throws RuntimeException
 	 * @throws ReflectionException
 	 *
 	 * @return AbstractComponent

--- a/src/LuaLibrary.php
+++ b/src/LuaLibrary.php
@@ -26,12 +26,12 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
+use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
+use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LuaEngine;
 use MediaWiki\MediaWikiServices;
 use MWException;
 use ReflectionClass;
 use ReflectionException;
-use Scribunto_LuaEngine;
-use Scribunto_LuaLibraryBase;
 
 /**
  * Class LuaLibrary
@@ -40,7 +40,7 @@ use Scribunto_LuaLibraryBase;
  *
  * @since 1.1
  */
-class LuaLibrary extends Scribunto_LuaLibraryBase {
+class LuaLibrary extends LibraryBase {
 
 	/**
 	 * @var ApplicationFactory $applicationFactory;
@@ -55,9 +55,9 @@ class LuaLibrary extends Scribunto_LuaLibraryBase {
 	/**
 	 * LuaLibrary constructor.
 	 *
-	 * @param Scribunto_LuaEngine $engine
+	 * @param LuaEngine $engine
 	 */
-	public function __construct( Scribunto_LuaEngine $engine ) {
+	public function __construct( LuaEngine $engine ) {
 		parent::__construct( $engine );
 		$this->applicationFactory = ApplicationFactory::getInstance();
 		$this->bootstrapComponentService = MediaWikiServices::getInstance()->getService( 'BootstrapComponentsService' );

--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -100,13 +100,6 @@ class ModalBuilder {
 	private $outerStyle;
 
 	/**
-	 * @var ParserOutputHelper $parserOutputHelper
-	 *
-	 * @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
-	 */
-	private $parserOutputHelper;
-
-	/**
 	 * @var string $trigger
 	 */
 	private $trigger;
@@ -144,21 +137,17 @@ class ModalBuilder {
 	 * Do not instantiate directly, but use {@see ApplicationFactory::getNewModalBuilder}
 	 * instead.
 	 *
-	 * @param string             $id
-	 * @param string             $trigger must be safe raw html (best run through {@see Parser::recursiveTagParse})
-	 * @param string             $content must be fully parsed html (use {@see Parser::recursiveTagParseFully})
-	 * @param ParserOutputHelper $parserOutputHelper @deprecated unused since the inline-emission modal fix; will be removed in the next major release.
+	 * @param string $id
+	 * @param string $trigger must be safe raw html (best run through {@see Parser::recursiveTagParse})
+	 * @param string $content must be fully parsed html (use {@see Parser::recursiveTagParseFully})
 	 *
 	 * @see ApplicationFactory::getNewModalBuilder
 	 * @see Components\Modal::generateButton
-	 *
 	 */
-
-	public function __construct( $id, $trigger, $content, $parserOutputHelper ) {
+	public function __construct( $id, $trigger, $content ) {
 		$this->id = $id;
 		$this->trigger = $trigger;
 		$this->content = $content;
-		$this->parserOutputHelper = $parserOutputHelper;
 	}
 
 	/**

--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -26,8 +26,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-use \Html;
-use MediaWiki\MediaWikiServices;
+use MediaWiki\Html\Html;
 
 /**
  * Class ModalBase

--- a/src/NestingController.php
+++ b/src/NestingController.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents;
 
 use MediaWiki\MediaWikiServices;
-use MWException;
+use RuntimeException;
 
 /**
  * Class NestingController
@@ -72,15 +72,15 @@ class NestingController {
 	 *
 	 * @param string|false $id id of the current object we are trying to close
 	 *
-	 * @throws MWException if current and closing component is different
+	 * @throws RuntimeException if current and closing component is different
 	 */
 	public function close( $id ): void {
 		$current = $this->getCurrentElement();
 		if ( !$current ) {
-			throw new MWException( 'Nesting error. Tried to close an empty stack.' );
+			throw new RuntimeException( 'Nesting error. Tried to close an empty stack.' );
 		}
 		if ( $id === false || ($current->getId() != $id) ) {
-			throw new MWException( 'Nesting error. Trying to close a component that is not the currently open one.' );
+			throw new RuntimeException( 'Nesting error. Trying to close a component that is not the currently open one.' );
 		}
 		array_pop( $this->componentStack );
 	}
@@ -124,11 +124,11 @@ class NestingController {
 	 *
 	 * @param NestableInterface $nestable
 	 *
-	 * @throws MWException when open is called with an invalid object
+	 * @throws RuntimeException when open is called with an invalid object
 	 */
 	public function open( mixed &$nestable ): void {
 		if ( !$nestable instanceof NestableInterface ) {
-			throw new MWException( 'Nesting error. Trying to put an object other than a Component an the nesting stack.' );
+			throw new RuntimeException( 'Nesting error. Trying to put an object other than a Component an the nesting stack.' );
 		}
 		$this->componentStack[] = $nestable;
 	}

--- a/src/ParserOutputHelper.php
+++ b/src/ParserOutputHelper.php
@@ -115,21 +115,6 @@ class ParserOutputHelper {
 	}
 
 	/**
-	 * Unless I find a solution for the integration test problem, I cannot use an instance of
-	 * ParserOutputHelper in ImageModal to ascertain this. In integration tests, "we" use a
-	 * different parser than the InternalParseBeforeLinks-Hook. At least, after I added
-	 * Scribunto _unit_ tests. All messed up, I'm afraid. ImageModal better use global parser, and
-	 * for the time being this method will be
-	 * @deprecated
-	 *
-	 * @return bool|null
-	 */
-	public function areImageModalsSuppressed() {
-		return $this->getParser()->getOutput()
-			->getExtensionData( BootstrapComponents::EXTENSION_DATA_NO_IMAGE_MODAL );
-	}
-
-	/**
 	 * Formats a text as error text, so it can be added to the output.
 	 *
 	 * @param string $errorMessageName

--- a/src/ParserOutputHelper.php
+++ b/src/ParserOutputHelper.php
@@ -26,20 +26,11 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
-/*
- * TODO: When dropping support for MW1.39, use these class imports:
 use MediaWiki\Html\Html;
 use MediaWiki\Message\Message;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
-*/
-
-use Html;
-use Message;
-use Parser;
-use ParserOutput;
-use Title;
 
 
 /**

--- a/src/ParserRequest.php
+++ b/src/ParserRequest.php
@@ -26,8 +26,8 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
+use MediaWiki\Parser\Parser;
 use MWException;
-use Parser;
 use PPFrame;
 
 /**

--- a/src/ParserRequest.php
+++ b/src/ParserRequest.php
@@ -27,7 +27,7 @@
 namespace MediaWiki\Extension\BootstrapComponents;
 
 use MediaWiki\Parser\Parser;
-use MWException;
+use RuntimeException;
 use PPFrame;
 
 /**
@@ -70,7 +70,7 @@ class ParserRequest {
 	 *
 	 * @see ApplicationFactory::getNewParserRequest
 	 *
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function __construct(
 		array $argumentsPassedByParser, bool $isParserFunction, string $componentName = 'unknown'
@@ -79,10 +79,10 @@ class ParserRequest {
 			$this->processArguments( $argumentsPassedByParser, $isParserFunction, $componentName );
 		$this->attributes = (array)$attributes;
 		if ( !$parser || !is_a( $parser, 'Parser' ) ) {
-			throw new MWException( 'Invalid parser object passed to component ' . $componentName . '!' );
+			throw new RuntimeException( 'Invalid parser object passed to component ' . $componentName . '!' );
 		}
 		if ( $frame && !is_a( $frame, 'PPFrame' ) ) {
-			throw new MWException( 'Invalid frame object passed to component ' . $componentName . '!' );
+			throw new RuntimeException( 'Invalid frame object passed to component ' . $componentName . '!' );
 		}
 		$this->parser = $parser;
 		$this->frame = $frame;
@@ -142,7 +142,7 @@ class ParserRequest {
 	 * @param array  $options
 	 * @param string $componentName
 	 *
-	 * @throws MWException
+	 * @throws RuntimeException
 	 * @return array $results
 	 */
 	private function extractParserFunctionOptions( array $options, string $componentName ): array {
@@ -152,7 +152,7 @@ class ParserRequest {
 		$results = [];
 		foreach ( $options as $option ) {
 			if ( !is_string( $option ) ) {
-				throw new MWException(
+				throw new RuntimeException(
 					'Arguments passed to bootstrap component "' . $componentName . '" are invalid!'
 				);
 			}
@@ -194,7 +194,7 @@ class ParserRequest {
 	 * @param bool   $isParserFunction
 	 * @param string $componentName
 	 *
-	 * @throws MWException if argument list does not match handler type or unknown handler type detected
+	 * @throws RuntimeException if argument list does not match handler type or unknown handler type detected
 	 * @return array array consisting of (string) $input, (array) $options, (Parser) $parser, and optional (PPFrame) $frame
 	 */
 	private function processArguments(
@@ -210,7 +210,7 @@ class ParserRequest {
 			return [ $input, $attributes, $parser, null ];
 		} else {
 			if ( count( $argumentsPassedByParser ) != 4 ) {
-				throw new MWException(
+				throw new RuntimeException(
 					'Argument list passed to bootstrap tag component "' . $componentName . '" is invalid!'
 				);
 			}

--- a/tests/PhpUnitEnvironment.php
+++ b/tests/PhpUnitEnvironment.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests;
 
-use \GitInfo;
+use GitInfo;
 
 /**
  * @private

--- a/tests/phpunit/Fixtures/TestConfig.php
+++ b/tests/phpunit/Fixtures/TestConfig.php
@@ -3,8 +3,8 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Fixtures;
 
 use ArrayIterator;
-use Config;
-use ConfigException;
+use MediaWiki\Config\Config;
+use MediaWiki\Config\ConfigException;
 use MediaWiki\Config\IterableConfig;
 use MutableConfig;
 use Traversable;

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Integration;
 
-use \MediaWiki\MediaWikiServices;
+use MediaWiki\MediaWikiServices;
 use SMW\Tests\PHPUnitCompat;
 use SMW\Tests\Utils\UtilityFactory;
 

--- a/tests/phpunit/Integration/JSONScript/BootstrapComponentsJsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/BootstrapComponentsJsonTestCaseScriptRunnerTest.php
@@ -3,8 +3,8 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Integration;
 
 use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
-use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
 use MediaWiki\Extension\BootstrapComponents\HookRegistry;
+use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
 use SMW\DIWikiPage;
 use SMW\Tests\JSONScriptTestCaseRunner;
 use SMW\Tests\Utils\JSONScript\JsonTestCaseFileHandler;

--- a/tests/phpunit/Integration/JSONScript/BootstrapComponentsJsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/BootstrapComponentsJsonTestCaseScriptRunnerTest.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Integration;
 
 use MediaWiki\Extension\BootstrapComponents\ApplicationFactory;
+use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\HookRegistry;
 use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
 use SMW\DIWikiPage;
@@ -196,8 +197,9 @@ class BootstrapComponentsJSONScriptTestCaseRunnerTest extends JSONScriptTestCase
 			$outputPage = $this->getMockBuilder( 'OutputPage' )
 				->disableOriginalConstructor()
 				->getMock();
+			$bootstrapService = $this->createMock( BootstrapComponentsService::class );
 			/** @noinspection PhpParamsInspection */
-			$hook = new OutputPageParserOutput( $outputPage, $parserOutput );
+			$hook = new OutputPageParserOutput( $outputPage, $bootstrapService );
 			$hook->process();
 		} catch ( \Exception $e ) {
 			// nothing

--- a/tests/phpunit/Integration/JSONScript/BootstrapComponentsJsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/BootstrapComponentsJsonTestCaseScriptRunnerTest.php
@@ -42,7 +42,7 @@ class BootstrapComponentsJSONScriptTestCaseRunnerTest extends JSONScriptTestCase
 
 	/**
 	 * @throws \ConfigException
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	protected function setUp(): void {
 		wfDebugLog( 'BootstrapComponents', 'Running the JSONScriptTestCaseRunnerTest setup.' );

--- a/tests/phpunit/Unit/AbstractComponentTest.php
+++ b/tests/phpunit/Unit/AbstractComponentTest.php
@@ -120,14 +120,8 @@ class AbstractComponentTest extends ComponentsTestBase {
 		}
 		$this->assertIsString( $parsedString );
 
-		// TODO when we drop support for MW1.39
-		if ( version_compare( $GLOBALS['wgVersion'], '1.40', 'lt' ) ) {
-			$this->assertRegExp( '/class="[^"]*test-class"/', $parsedString );
-			$this->assertRegExp( '/style="[^"]*color:black"/', $parsedString );
-		} else {
-			$this->assertMatchesRegularExpression( '/class="[^"]*test-class"/', $parsedString );
-			$this->assertMatchesRegularExpression( '/style="[^"]*color:black"/', $parsedString );
-		}
+		$this->assertMatchesRegularExpression( '/class="[^"]*test-class"/', $parsedString );
+		$this->assertMatchesRegularExpression( '/style="[^"]*color:black"/', $parsedString );
 	}
 
 	/**

--- a/tests/phpunit/Unit/AbstractComponentTest.php
+++ b/tests/phpunit/Unit/AbstractComponentTest.php
@@ -5,7 +5,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\NestableInterface;
-use MWException;
+use RuntimeException;
 use PHPUnit\Framework\MockObject\Stub;
 
 /**
@@ -75,7 +75,7 @@ class AbstractComponentTest extends ComponentsTestBase {
 	}
 
 	/**
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testParseComponent() {
 		$parserRequest = $this->buildParserRequest(
@@ -96,7 +96,7 @@ class AbstractComponentTest extends ComponentsTestBase {
 	/**
 	 * @param string $component
 	 *
-	 * @throws MWException
+	 * @throws RuntimeException
 	 * @dataProvider allComponentsProvider
 	 */
 	public function testSimpleOutput( string $component ) {
@@ -127,7 +127,7 @@ class AbstractComponentTest extends ComponentsTestBase {
 	/**
 	 * @param string $component
 	 *
-	 * @throws MWException
+	 * @throws RuntimeException
 	 * @dataProvider allComponentsProvider
 	 */
 	public function testInvalidParserRequest( $component ) {
@@ -138,7 +138,7 @@ class AbstractComponentTest extends ComponentsTestBase {
 			$this->getParserOutputHelper(),
 			$this->getNestingController()
 		);
-		$this->expectException( 'MWException' );
+		$this->expectException( RuntimeException::class );
 		/** @noinspection PhpParamsInspection */
 		$instance->parseComponent(
 			'noParser'

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -7,6 +7,7 @@ use MediaWiki\Extension\BootstrapComponents\ModalBuilder;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
 use MediaWiki\Extension\BootstrapComponents\ParserRequest;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\ApplicationFactory
@@ -83,7 +84,7 @@ class ApplicationFactoryTest extends TestCase {
 	 * @param array $arguments
 	 * @param bool  $isParserFunction
 	 *
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 *
 	 * @dataProvider parserRequestProvider
 	 */
@@ -97,7 +98,7 @@ class ApplicationFactoryTest extends TestCase {
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testGetParserOutputHelper() {
 		$instance = new ApplicationFactory();
@@ -120,13 +121,13 @@ class ApplicationFactoryTest extends TestCase {
 	public function testFailingGetNewParserRequest( array $arguments, bool $isParserFunction ) {
 		$instance = new ApplicationFactory();
 
-		$this->expectException( 'MWException' );
+		$this->expectException( RuntimeException::class );
 
 		$instance->getNewParserRequest( $arguments, $isParserFunction );
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRegisterApplication() {
 		$instance = new ApplicationFactory();
@@ -136,7 +137,7 @@ class ApplicationFactoryTest extends TestCase {
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanNotRegisterApplicationOnInvalidName() {
 		$instance = new ApplicationFactory();
@@ -150,7 +151,7 @@ class ApplicationFactoryTest extends TestCase {
 
 	public function testCanNotRegisterApplicationOnInvalidClass() {
 		$instance = new ApplicationFactory();
-		$this->expectException( 'MWException' );
+		$this->expectException( RuntimeException::class );
 		$instance->registerApplication( 'test', 'FooBar' );
 	}
 

--- a/tests/phpunit/Unit/ApplicationFactoryTest.php
+++ b/tests/phpunit/Unit/ApplicationFactoryTest.php
@@ -68,11 +68,9 @@ class ApplicationFactoryTest extends TestCase {
 	}
 
 	public function testGetNewModalBuilder() {
-		$parserOutputHelper = $this->createMock( ParserOutputHelper::class );
-
 		$factory = new ApplicationFactory();
 
-		$modalBuilder = $factory->getNewModalBuilder( '', '', '', $parserOutputHelper );
+		$modalBuilder = $factory->getNewModalBuilder( '', '', '' );
 
 		$this->assertInstanceOf(
 			ModalBuilder::class,

--- a/tests/phpunit/Unit/BootstrapComponentServiceTest.php
+++ b/tests/phpunit/Unit/BootstrapComponentServiceTest.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
-use Config;
+use MediaWiki\Config\Config;
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\Tests\Fixtures\TestConfig;
 use PHPUnit\Framework\TestCase;

--- a/tests/phpunit/Unit/CarouselGalleryTest.php
+++ b/tests/phpunit/Unit/CarouselGalleryTest.php
@@ -3,10 +3,9 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\CarouselGallery;
-use MediaWiki\Extension\BootstrapComponents\ParserRequest;
-use \MWException;
+use MediaWiki\Title\Title;
+use MWException;
 use PHPUnit\Framework\TestCase;
-use \Title;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\CarouselGallery

--- a/tests/phpunit/Unit/CarouselGalleryTest.php
+++ b/tests/phpunit/Unit/CarouselGalleryTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\CarouselGallery;
 use MediaWiki\Title\Title;
-use MWException;
+use RuntimeException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -35,7 +35,7 @@ class CarouselGalleryTest extends TestCase {
 	 * @param array  $additionalAttributes
 	 * @param string $expectedOutput
 	 *
-	 * @throws MWException
+	 * @throws RuntimeException
 	 * @dataProvider galleryDataProvider
 	 */
 	public function testToHtml( $imageList, $additionalAttributes, $expectedOutput ) {

--- a/tests/phpunit/Unit/ComponentLibraryTest.php
+++ b/tests/phpunit/Unit/ComponentLibraryTest.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
-use ConfigException;
+use MediaWiki\Config\ConfigException;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/phpunit/Unit/ComponentLibraryTest.php
+++ b/tests/phpunit/Unit/ComponentLibraryTest.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 use MediaWiki\Config\ConfigException;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\ComponentLibrary
@@ -76,7 +77,7 @@ class ComponentLibraryTest extends TestCase {
 	 * @param string[] $expectedAliases
 	 *
 	 * @throws ConfigException
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 *
 	 * @dataProvider componentAliasesProvider
 	 */
@@ -93,7 +94,7 @@ class ComponentLibraryTest extends TestCase {
 	 * @param string[] $expectedAttributes
 	 *
 	 * @throws ConfigException
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 *
 	 * @dataProvider componentAttributesProvider
 	 */
@@ -203,7 +204,7 @@ class ComponentLibraryTest extends TestCase {
 	 * @param string $componentClass
 	 *
 	 * @throws ConfigException
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 *
 	 * @dataProvider componentNameAndClassProvider
 	 */
@@ -242,7 +243,7 @@ class ComponentLibraryTest extends TestCase {
 	public function testFails( $method, $param ) {
 		$instance = new ComponentLibrary();
 
-		$this->expectException( 'MWException' );
+		$this->expectException( RuntimeException::class );
 
 		call_user_func_array( [ $instance, $method ], [ $param ] );
 	}
@@ -279,7 +280,7 @@ class ComponentLibraryTest extends TestCase {
 	public function testUnknownComponentName() {
 		$instance = new ComponentLibrary( true );
 
-		$this->expectException( 'MWException' );
+		$this->expectException( RuntimeException::class );
 		$instance->getClassFor( 'foobar' );
 	}
 
@@ -289,7 +290,7 @@ class ComponentLibraryTest extends TestCase {
 	public function testUnknownComponentClass() {
 		$instance = new ComponentLibrary( true );
 
-		$this->expectException( 'MWException' );
+		$this->expectException( RuntimeException::class );
 		$instance->getNameFor( '\BootstrapComponents\Components\Foobar' );
 	}
 

--- a/tests/phpunit/Unit/Components/AccordionTest.php
+++ b/tests/phpunit/Unit/Components/AccordionTest.php
@@ -2,9 +2,9 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
-use MediaWiki\Extension\BootstrapComponents\Components\Accordion as Accordion;
+use MediaWiki\Extension\BootstrapComponents\Components\Accordion;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Accordion

--- a/tests/phpunit/Unit/Components/AccordionTest.php
+++ b/tests/phpunit/Unit/Components/AccordionTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Accordion;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Accordion
@@ -24,7 +24,7 @@ class AccordionTest extends ComponentsTestBase {
 	private $input = 'Accordion test text';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -44,7 +44,7 @@ class AccordionTest extends ComponentsTestBase {
 	 * @param string $expectedOutput
 	 *
 	 * @dataProvider placeMeArgumentsProvider
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRender( $input, $arguments, $expectedOutput ) {
 		$instance = new Accordion(

--- a/tests/phpunit/Unit/Components/AlertTest.php
+++ b/tests/phpunit/Unit/Components/AlertTest.php
@@ -57,18 +57,10 @@ class AlertTest extends ComponentsTestBase {
 
 		$generatedOutput = $instance->parseComponent( $parserRequest );
 
-		// TODO when we drop support for MW1.39
-		if ( version_compare( $GLOBALS['wgVersion'], '1.40', 'lt' ) ) {
-			$this->assertRegExp(
-				'~^<div.+class="alert alert-.+".*role="alert".*>' . $this->input . '(<button.*button>)?</div>$~',
-				$generatedOutput
-			);
-		} else {
-			$this->assertMatchesRegularExpression(
-				'~^<div.+class="alert alert-.+".*role="alert".*>' . $this->input . '(<button.*button>)?</div>$~',
-				$generatedOutput
-			);
-		}
+		$this->assertMatchesRegularExpression(
+			'~^<div.+class="alert alert-.+".*role="alert".*>' . $this->input . '(<button.*button>)?</div>$~',
+			$generatedOutput
+		);
 
 		$this->assertEquals( $expectedOutput, $generatedOutput );
 	}

--- a/tests/phpunit/Unit/Components/AlertTest.php
+++ b/tests/phpunit/Unit/Components/AlertTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Alert;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Alert

--- a/tests/phpunit/Unit/Components/AlertTest.php
+++ b/tests/phpunit/Unit/Components/AlertTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Alert;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Alert
@@ -24,7 +24,7 @@ class AlertTest extends ComponentsTestBase {
 	private $input = 'Alert test text';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -44,7 +44,7 @@ class AlertTest extends ComponentsTestBase {
 	 * @param string $expectedOutput
 	 *
 	 * @dataProvider placeMeArgumentsProvider
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRender( $input, $arguments, $expectedOutput ) {
 		$instance = new Alert(

--- a/tests/phpunit/Unit/Components/BadgeTest.php
+++ b/tests/phpunit/Unit/Components/BadgeTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Badge;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Badge
@@ -24,7 +24,7 @@ class BadgeTest extends ComponentsTestBase {
 	private $input = 'Badge test text';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -44,7 +44,7 @@ class BadgeTest extends ComponentsTestBase {
 	 * @param string $expectedOutput
 	 *
 	 * @dataProvider placeMeArgumentsProvider
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRender( $input, $arguments, $expectedOutput ) {
 		$instance = new Badge(

--- a/tests/phpunit/Unit/Components/BadgeTest.php
+++ b/tests/phpunit/Unit/Components/BadgeTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Badge;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Badge

--- a/tests/phpunit/Unit/Components/ButtonTest.php
+++ b/tests/phpunit/Unit/Components/ButtonTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Button;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Button
@@ -24,7 +24,7 @@ class ButtonTest extends ComponentsTestBase {
 	private $input = 'Button test text';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -44,7 +44,7 @@ class ButtonTest extends ComponentsTestBase {
 	 * @param string $expectedOutputPattern
 	 *
 	 * @dataProvider placeMeArgumentsProvider
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRender( $input, $arguments, $expectedOutputPattern ) {
 		$instance = new Button(
@@ -64,7 +64,7 @@ class ButtonTest extends ComponentsTestBase {
 	}
 
 	/**
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanInjectRawAttributes() {
 

--- a/tests/phpunit/Unit/Components/ButtonTest.php
+++ b/tests/phpunit/Unit/Components/ButtonTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Button;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Button

--- a/tests/phpunit/Unit/Components/ButtonTest.php
+++ b/tests/phpunit/Unit/Components/ButtonTest.php
@@ -60,12 +60,7 @@ class ButtonTest extends ComponentsTestBase {
 			$generatedOutput = $generatedOutput[0];
 		}
 
-		// TODO when we drop support for MW1.39
-		if ( version_compare( $GLOBALS['wgVersion'], '1.40', 'lt' ) ) {
-			$this->assertRegExp( $expectedOutputPattern, $generatedOutput );
-		} else {
-			$this->assertMatchesRegularExpression( $expectedOutputPattern, $generatedOutput );
-		}
+		$this->assertMatchesRegularExpression( $expectedOutputPattern, $generatedOutput );
 	}
 
 	/**
@@ -93,22 +88,12 @@ class ButtonTest extends ComponentsTestBase {
 			$generatedOutput = $generatedOutput[0];
 		}
 
-		// TODO when we drop support for MW1.39
-		if ( version_compare( $GLOBALS['wgVersion'], '1.40', 'lt' ) ) {
-			$this->assertRegExp(
-				'~^<a class="btn btn-primary btn-md manual" role="button" id="bsc_button_NULL" href=".*/'
-				. str_replace( ' ', '_', $this->input )
-				. '" data-toggle="foo" data-target="#bar">' . $this->input . '</a>$~',
-				$generatedOutput
-			);
-		} else {
-			$this->assertMatchesRegularExpression(
-				'~^<a class="btn btn-primary btn-md manual" role="button" id="bsc_button_NULL" href=".*/'
-				. str_replace( ' ', '_', $this->input )
-				. '" data-toggle="foo" data-target="#bar">' . $this->input . '</a>$~',
-				$generatedOutput
-			);
-		}
+		$this->assertMatchesRegularExpression(
+			'~^<a class="btn btn-primary btn-md manual" role="button" id="bsc_button_NULL" href=".*/'
+			. str_replace( ' ', '_', $this->input )
+			. '" data-toggle="foo" data-target="#bar">' . $this->input . '</a>$~',
+			$generatedOutput
+		);
 	}
 
 	/**

--- a/tests/phpunit/Unit/Components/CardTest.php
+++ b/tests/phpunit/Unit/Components/CardTest.php
@@ -6,7 +6,7 @@ use MediaWiki\Extension\BootstrapComponents\Components\Accordion;
 use MediaWiki\Extension\BootstrapComponents\Components\Card;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Card

--- a/tests/phpunit/Unit/Components/CardTest.php
+++ b/tests/phpunit/Unit/Components/CardTest.php
@@ -6,7 +6,7 @@ use MediaWiki\Extension\BootstrapComponents\Components\Accordion;
 use MediaWiki\Extension\BootstrapComponents\Components\Card;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Card
@@ -26,7 +26,7 @@ class CardTest extends ComponentsTestBase {
 	private $input = 'Card test text';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -45,7 +45,7 @@ class CardTest extends ComponentsTestBase {
 	 * @param array  $arguments
 	 * @param string $expectedOutput
 	 *
-	 * @throws MWException
+	 * @throws RuntimeException
 	 *
 	 * @dataProvider placeMeArgumentsProvider
 	 */
@@ -69,7 +69,7 @@ class CardTest extends ComponentsTestBase {
 	 * @param array  $arguments
 	 * @param string $expectedOutput
 	 *
-	 * @throws MWException
+	 * @throws RuntimeException
 	 *
 	 * @dataProvider placeMeInsideAccordionArgumentsProvider
 	 */

--- a/tests/phpunit/Unit/Components/CarouselTest.php
+++ b/tests/phpunit/Unit/Components/CarouselTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Carousel;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Carousel

--- a/tests/phpunit/Unit/Components/CarouselTest.php
+++ b/tests/phpunit/Unit/Components/CarouselTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Carousel;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Carousel
@@ -24,7 +24,7 @@ class CarouselTest extends ComponentsTestBase {
 	private $input = 'Botched input';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -44,7 +44,7 @@ class CarouselTest extends ComponentsTestBase {
 	 * @param string $expectedOutput
 	 *
 	 * @dataProvider placeMeArgumentsProvider
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRender( $input, $arguments, $expectedOutput ) {
 		$instance = new Carousel(

--- a/tests/phpunit/Unit/Components/CollapseTest.php
+++ b/tests/phpunit/Unit/Components/CollapseTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Collapse;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Collapse

--- a/tests/phpunit/Unit/Components/CollapseTest.php
+++ b/tests/phpunit/Unit/Components/CollapseTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Collapse;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Collapse
@@ -24,7 +24,7 @@ class CollapseTest extends ComponentsTestBase {
 	private $input = 'Collapse test text';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -44,7 +44,7 @@ class CollapseTest extends ComponentsTestBase {
 	 * @param string $expectedOutput
 	 *
 	 * @dataProvider placeMeArgumentsProvider
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRender( $input, $arguments, $expectedOutput ) {
 		$instance = new Collapse(

--- a/tests/phpunit/Unit/Components/JumbotronTest.php
+++ b/tests/phpunit/Unit/Components/JumbotronTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Jumbotron;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Jumbotron

--- a/tests/phpunit/Unit/Components/JumbotronTest.php
+++ b/tests/phpunit/Unit/Components/JumbotronTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Jumbotron;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Jumbotron
@@ -24,7 +24,7 @@ class JumbotronTest extends ComponentsTestBase {
 	private $input = 'Jumbotron test text';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -44,7 +44,7 @@ class JumbotronTest extends ComponentsTestBase {
 	 * @param string $expectedOutput
 	 *
 	 * @dataProvider placeMeArgumentsProvider
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRender( $input, $arguments, $expectedOutput ) {
 		$instance = new Jumbotron(

--- a/tests/phpunit/Unit/Components/ModalTest.php
+++ b/tests/phpunit/Unit/Components/ModalTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Modal;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Modal
@@ -24,7 +24,7 @@ class ModalTest extends ComponentsTestBase {
 	private $input = 'Modal test text';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -45,7 +45,7 @@ class ModalTest extends ComponentsTestBase {
 	 * @param string $expectedModalOutput
 	 *
 	 * @dataProvider placeMeArgumentsProvider
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRender( $input, $arguments, $expectedTriggerOutput, $expectedModalOutput ) {
 

--- a/tests/phpunit/Unit/Components/ModalTest.php
+++ b/tests/phpunit/Unit/Components/ModalTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Modal;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Modal

--- a/tests/phpunit/Unit/Components/PopoverTest.php
+++ b/tests/phpunit/Unit/Components/PopoverTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Popover;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Popover
@@ -24,7 +24,7 @@ class PopoverTest extends ComponentsTestBase {
 	private $input = 'Popover test text';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -44,7 +44,7 @@ class PopoverTest extends ComponentsTestBase {
 	 * @param string $expectedOutput
 	 *
 	 * @dataProvider placeMeArgumentsProvider
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRender( $input, $arguments, $expectedOutput ) {
 		$instance = new Popover(

--- a/tests/phpunit/Unit/Components/PopoverTest.php
+++ b/tests/phpunit/Unit/Components/PopoverTest.php
@@ -4,7 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 
 use MediaWiki\Extension\BootstrapComponents\Components\Popover;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Popover

--- a/tests/phpunit/Unit/Components/TooltipTest.php
+++ b/tests/phpunit/Unit/Components/TooltipTest.php
@@ -5,7 +5,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 use MediaWiki\Extension\BootstrapComponents\Components\Tooltip;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use \MWException;
+use MWException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Tooltip

--- a/tests/phpunit/Unit/Components/TooltipTest.php
+++ b/tests/phpunit/Unit/Components/TooltipTest.php
@@ -5,7 +5,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Components;
 use MediaWiki\Extension\BootstrapComponents\Components\Tooltip;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\Tests\Unit\ComponentsTestBase;
-use MWException;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Components\Tooltip
@@ -25,7 +25,7 @@ class TooltipTest extends ComponentsTestBase {
 	private $input = 'Tooltip test text';
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -45,7 +45,7 @@ class TooltipTest extends ComponentsTestBase {
 	 * @param string $expectedOutput
 	 *
 	 * @dataProvider placeMeArgumentsProvider
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanRender( $input, $arguments, $expectedOutput ) {
 		$instance = new Tooltip(

--- a/tests/phpunit/Unit/ComponentsTestBase.php
+++ b/tests/phpunit/Unit/ComponentsTestBase.php
@@ -6,8 +6,8 @@ use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
 use MediaWiki\Extension\BootstrapComponents\ParserRequest;
+use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
-use Parser;
 use PPFrame;
 
 /**

--- a/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
@@ -5,7 +5,6 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Hooks;
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
 use MediaWiki\Output\OutputPage;
-use MediaWiki\Parser\ParserOutput;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -29,7 +28,6 @@ class OutputPageParserOutputTest extends TestCase {
 
 		$instance = new OutputPageParserOutput(
 			$outputPage,
-			$this->createMock( ParserOutput::class ),
 			$this->createMock( BootstrapComponentsService::class )
 		);
 
@@ -53,11 +51,7 @@ class OutputPageParserOutputTest extends TestCase {
 			->method( 'vectorSkinInUse' )
 			->willReturn( true );
 
-		$instance = new OutputPageParserOutput(
-			$outputPage,
-			$this->createMock( ParserOutput::class ),
-			$bootstrapService
-		);
+		$instance = new OutputPageParserOutput( $outputPage, $bootstrapService );
 		$instance->process();
 	}
 
@@ -71,11 +65,7 @@ class OutputPageParserOutputTest extends TestCase {
 			->method( 'vectorSkinInUse' )
 			->willReturn( false );
 
-		$instance = new OutputPageParserOutput(
-			$outputPage,
-			$this->createMock( ParserOutput::class ),
-			$bootstrapService
-		);
+		$instance = new OutputPageParserOutput( $outputPage, $bootstrapService );
 		$instance->process();
 	}
 }

--- a/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
@@ -4,8 +4,8 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Hooks;
 
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
-use OutputPage;
-use ParserOutput;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Parser\ParserOutput;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/phpunit/Unit/Hooks/ParserFirstCallInitTest.php
+++ b/tests/phpunit/Unit/Hooks/ParserFirstCallInitTest.php
@@ -2,9 +2,9 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Hooks;
 
-use MediaWiki\Extension\BootstrapComponents\Hooks\ParserFirstCallInit as ParserFirstCallInit;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
-use \Parser;
+use MediaWiki\Extension\BootstrapComponents\Hooks\ParserFirstCallInit;
+use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/phpunit/Unit/HooksHandlerTest.php
+++ b/tests/phpunit/Unit/HooksHandlerTest.php
@@ -6,8 +6,8 @@ use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\HooksHandler;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
-use Parser;
-use ParserOutput;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOutput;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/phpunit/Unit/ImageModalTest.php
+++ b/tests/phpunit/Unit/ImageModalTest.php
@@ -262,21 +262,13 @@ class ImageModalTest extends TestCase {
 
 		$resultOfParseCall = $instance->parse( $fp, $hp, $time, $res );
 
-		if ( version_compare( $GLOBALS['wgVersion'], '1.40', 'lt' ) ) {
-			$this->assertRegExp(
-				$expectedTrigger,
-				$resultOfParseCall ?: $res,
-				'failed with test data:' . $this->generatePhpCodeForManualProviderDataOneCase( $fp, $hp )
-			);
-		} else {
-			$this->assertMatchesRegularExpression(
-				$expectedTrigger,
-				$resultOfParseCall ?: $res,
-				'failed with test data:' . $this->generatePhpCodeForManualProviderDataOneCase( $fp, $hp )
-				. '++ ' . $expectedTrigger . PHP_EOL
-				. '--  ' . ($resultOfParseCall ?: $res)
-			);
-		}
+		$this->assertMatchesRegularExpression(
+			$expectedTrigger,
+			$resultOfParseCall ?: $res,
+			'failed with test data:' . $this->generatePhpCodeForManualProviderDataOneCase( $fp, $hp )
+			. '++ ' . $expectedTrigger . PHP_EOL
+			. '--  ' . ($resultOfParseCall ?: $res)
+		);
 		$this->assertStringContainsString(
 			$expectedModal,
 			$resultOfParseCall ?: $res,

--- a/tests/phpunit/Unit/ImageModalTest.php
+++ b/tests/phpunit/Unit/ImageModalTest.php
@@ -34,7 +34,7 @@ class ImageModalTest extends TestCase {
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCanConstruct() {
 
@@ -51,7 +51,7 @@ class ImageModalTest extends TestCase {
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 * @throws \ConfigException
 	 */
 	public function testCanParseOnFileNonExistent() {
@@ -77,7 +77,7 @@ class ImageModalTest extends TestCase {
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 * @throws \ConfigException
 	 */
 	public function testCanParseOnFileNoAllowInlineParse() {
@@ -103,7 +103,7 @@ class ImageModalTest extends TestCase {
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 * @throws \ConfigException
 	 */
 	public function testCanParseOnOnInvalidManualThumb() {
@@ -131,7 +131,7 @@ class ImageModalTest extends TestCase {
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 * @throws \ConfigException
 	 */
 	public function testCanParseOnOnInvalidContentImage() {
@@ -196,7 +196,7 @@ class ImageModalTest extends TestCase {
 	 * @param string $expectedTrigger
 	 * @param string $expectedModal
 	 *
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 * @throws \ConfigException
 	 *
 	 * @dataProvider canParseDataProvider

--- a/tests/phpunit/Unit/ImageModalTest.php
+++ b/tests/phpunit/Unit/ImageModalTest.php
@@ -2,17 +2,17 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
+use MediaWiki\Config\ConfigException;
 use File;
 use LocalFile;
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\ImageModal;
-use \ConfigException;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
-use \MediaWiki\MediaWikiServices;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use ThumbnailImage;
-use Title;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\ImageModal

--- a/tests/phpunit/Unit/ImageModalTest.php
+++ b/tests/phpunit/Unit/ImageModalTest.php
@@ -346,7 +346,7 @@ class ImageModalTest extends TestCase {
 					'framed'      => false,
 				],
 				[],
-				'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;">(<span>)?<img alt="" src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage" />(</span>)?  <div class="thumbcaption"></div></div></span></div>~',
+				'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;"><span><img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?></span>  <div class="thumbcaption"></div></div></span></div>~',
 				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div><div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div>'
 				. '<div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
@@ -378,7 +378,7 @@ class ImageModalTest extends TestCase {
 					'manualthumb' => 'Shuttle.png',
 				],
 				[],
-				'~<div class="thumb tleft"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;">(<span>)?<img alt="" src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage" />(</span>)?  <div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge"></a></div></div></div></span></div>~',
+				'~<div class="thumb tleft"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;"><span><img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?></span>  <div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge"></a></div></div></div></span></div>~',
 				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
 				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],

--- a/tests/phpunit/Unit/ImageModalTriggerTest.php
+++ b/tests/phpunit/Unit/ImageModalTriggerTest.php
@@ -3,7 +3,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\ImageModalTrigger;
-use \MediaWiki\MediaWikiServices;
+use MediaWiki\MediaWikiServices;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/phpunit/Unit/ImageModalTriggerTest.php
+++ b/tests/phpunit/Unit/ImageModalTriggerTest.php
@@ -254,7 +254,7 @@ class ImageModalTriggerTest extends TestCase {
 				[
 					'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
 					'~<div class="thumbinner" style="width:96px;">~',
-					'~<img alt="" src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage" />~',
+					'~<img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?>~',
 				]
 			],
 			'framed'                         => [
@@ -319,7 +319,7 @@ class ImageModalTriggerTest extends TestCase {
 				],
 				[
 					'~<div class="thumb tleft"><span class="modal-trigger" data-toggle="modal" data-target="#id"><div class="thumbinner" style="width:96px;">~',
-					'~<img alt="" src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage" />~',
+					'~<img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?>~',
 					'~<div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge">~',
 				]
 			],

--- a/tests/phpunit/Unit/ImageModalTriggerTest.php
+++ b/tests/phpunit/Unit/ImageModalTriggerTest.php
@@ -107,18 +107,10 @@ class ImageModalTriggerTest extends TestCase {
 		$resultOfParseCall = $instance->generate( $sfp, $hp );
 
 		foreach ( $expectedRegExp as $regExp ) {
-			// TODO when we drop support for MW1.39
-			if ( version_compare( $GLOBALS['wgVersion'], '1.40', 'lt' ) ) {
-				$this->assertRegExp(
-					$regExp, $resultOfParseCall,
-					'failed with test data:' . $this->generatePhpCodeForManualProviderDataOneCase( $sfp, $hp )
-				);
-			} else {
-				$this->assertMatchesRegularExpression(
-					$regExp, $resultOfParseCall,
-					'failed with test data:' . $this->generatePhpCodeForManualProviderDataOneCase( $sfp, $hp )
-				);
-			}
+			$this->assertMatchesRegularExpression(
+				$regExp, $resultOfParseCall,
+				'failed with test data:' . $this->generatePhpCodeForManualProviderDataOneCase( $sfp, $hp )
+			);
 		}
 	}
 

--- a/tests/phpunit/Unit/LuaLibraryTestBase.php
+++ b/tests/phpunit/Unit/LuaLibraryTestBase.php
@@ -23,7 +23,7 @@ abstract class LuaLibraryTestBase extends Scribunto_LuaEngineTestBase
 	private $luaLibrary;
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/Unit/LuaLibraryTestBase.php
+++ b/tests/phpunit/Unit/LuaLibraryTestBase.php
@@ -3,7 +3,7 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\LuaLibrary;
-use \Scribunto_LuaEngineTestBase;
+use Scribunto_LuaEngineTestBase;
 
 /**
  * @ingroup Test

--- a/tests/phpunit/Unit/ModalBuilderTest.php
+++ b/tests/phpunit/Unit/ModalBuilderTest.php
@@ -21,12 +21,7 @@ use PHPUnit\Framework\TestCase;
 class ModalBuilderTest extends TestCase {
 
 	public function testCanConstruct() {
-		$parserOutputHelper = $this->getMockBuilder( 'MediaWiki\\Extension\\BootstrapComponents\\ParserOutputHelper' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		/** @noinspection PhpParamsInspection */
-		$instance = new ModalBuilder( 'id', 'trigger', '', $parserOutputHelper );
+		$instance = new ModalBuilder( 'id', 'trigger', '' );
 		$this->assertInstanceOf(
 			'MediaWiki\\Extension\\BootstrapComponents\\ModalBuilder',
 			$instance
@@ -48,13 +43,7 @@ class ModalBuilderTest extends TestCase {
 	 * @dataProvider parseDataProvider
 	 */
 	public function testCanParse( $id, $trigger, $content, $header, $footer, $outerClass, $outerStyle, $innerClass, $expectedTrigger, $expectedModal ) {
-
-		$parserOutputHelper = $this->getMockBuilder( 'MediaWiki\\Extension\\BootstrapComponents\\ParserOutputHelper' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		/** @noinspection PhpParamsInspection */
-		$instance = new ModalBuilder( $id, $trigger, $content, $parserOutputHelper );
+		$instance = new ModalBuilder( $id, $trigger, $content );
 		if ( $header ) {
 			$instance->setHeader( $header );
 		}

--- a/tests/phpunit/Unit/NestingControllerTest.php
+++ b/tests/phpunit/Unit/NestingControllerTest.php
@@ -6,6 +6,7 @@ use MediaWiki\Extension\BootstrapComponents\AbstractComponent;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\NestingController
@@ -86,23 +87,23 @@ class NestingControllerTest extends TestCase {
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCloseFailOnEmptyStack() {
 		$instance = new NestingController();
 
-		$this->expectException( 'MWException' );
+		$this->expectException( RuntimeException::class );
 
 		$instance->close( 'invalid' );
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testOpenFail() {
 		$instance = new NestingController();
 
-		$this->expectException( 'MWException' );
+		$this->expectException( RuntimeException::class );
 
 		$component = 'invalid';
 		/** @noinspection PhpParamsInspection */
@@ -110,12 +111,12 @@ class NestingControllerTest extends TestCase {
 	}
 
 	/**
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function testCloseFailOnInvalidId() {
 		$instance = new NestingController();
 
-		$this->expectException( 'MWException' );
+		$this->expectException( RuntimeException::class );
 
 		/** @var AbstractComponent $component */
 		$component = $this->getComponent( 'panel', 'MediaWiki\\Extension\\BootstrapComponents\\Components\\Card' );
@@ -147,7 +148,7 @@ class NestingControllerTest extends TestCase {
 	 * @return array[]
 	 *
 	 * @throws \ConfigException
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 */
 	public function componentNameAndClassProvider() {
 		$cl = new ComponentLibrary();

--- a/tests/phpunit/Unit/ParserOutputHelperTest.php
+++ b/tests/phpunit/Unit/ParserOutputHelperTest.php
@@ -89,15 +89,10 @@ class ParserOutputHelperTest extends TestCase {
 			$this->buildFullyEquippedParser( ( $renderedMessageRegExp != '~^$~' ) )
 		);
 
-		// TODO when we drop support for MW1.39
-		if ( version_compare( $GLOBALS['wgVersion'], '1.40', 'lt' ) ) {
-			$this->assertRegExp( $renderedMessageRegExp, $instance->renderErrorMessage( $messageText ) );
-		} else {
-			$this->assertMatchesRegularExpression(
-				$renderedMessageRegExp,
-				$instance->renderErrorMessage( $messageText )
-			);
-		}
+		$this->assertMatchesRegularExpression(
+			$renderedMessageRegExp,
+			$instance->renderErrorMessage( $messageText )
+		);
 
 	}
 

--- a/tests/phpunit/Unit/ParserOutputHelperTest.php
+++ b/tests/phpunit/Unit/ParserOutputHelperTest.php
@@ -6,7 +6,7 @@ use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOutput;
-use MWException;
+use RuntimeException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -100,7 +100,7 @@ class ParserOutputHelperTest extends TestCase {
 	 * @return array[]
 	 *
 	 * @throws \ConfigException
-	 * @throws MWException
+	 * @throws RuntimeException
 	 */
 	public function componentNameAndClassProvider() {
 		$cl = new ComponentLibrary();

--- a/tests/phpunit/Unit/ParserOutputHelperTest.php
+++ b/tests/phpunit/Unit/ParserOutputHelperTest.php
@@ -4,10 +4,9 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\ParserOutputHelper;
-use \MWException;
-// TODO: when dropping 1.39, switch to MediaWiki\Parser\Parser and MediaWiki\Parser\ParserOutput
-use Parser;
-use ParserOutput;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOutput;
+use MWException;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/phpunit/Unit/ParserRequestTest.php
+++ b/tests/phpunit/Unit/ParserRequestTest.php
@@ -6,6 +6,7 @@ use MediaWiki\Extension\BootstrapComponents\ParserRequest;
 use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
 use PPFrame;
+use RuntimeException;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\ParserRequest
@@ -45,7 +46,7 @@ class ParserRequestTest extends TestCase {
 	 * @param array $arguments
 	 * @param bool  $isParserFunction
 	 *
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 *
 	 * @dataProvider constructionProvider
 	 */
@@ -65,7 +66,7 @@ class ParserRequestTest extends TestCase {
 	 */
 	public function testCanNotConstruct( array $arguments, bool $isParserFunction ) {
 
-		$this->expectException( 'MWException' );
+		$this->expectException( RuntimeException::class );
 
 		$this->assertInstanceOf(
 			ParserRequest::class,
@@ -79,7 +80,7 @@ class ParserRequestTest extends TestCase {
 	 * @param string $expectedInput
 	 * @param array  $expectedAttributes
 	 *
-	 * @throws \MWException
+	 * @throws RuntimeException
 	 *
 	 * @dataProvider constructionProvider
 	 */

--- a/tests/phpunit/Unit/ParserRequestTest.php
+++ b/tests/phpunit/Unit/ParserRequestTest.php
@@ -3,9 +3,9 @@
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit;
 
 use MediaWiki\Extension\BootstrapComponents\ParserRequest;
+use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
-use \Parser;
-use \PPFrame;
+use PPFrame;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\ParserRequest


### PR DESCRIPTION
Modernise the extension under a current MediaWiki + PHP baseline, ahead
of the Bootstrap 5 migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
