### PR TITLE
Modernize PHP

### DIFF
--- a/src/AbstractComponent.php
+++ b/src/AbstractComponent.php
@@ -56,11 +56,6 @@ abstract class AbstractComponent implements NestableInterface {
 	 */
 	private $id;
 
-	/**
-	 * Name of the component
-	 *
-	 * @var string $name
-	 */
 	private $name;
 
 	/**

--- a/src/AbstractComponent.php
+++ b/src/AbstractComponent.php
@@ -37,54 +37,24 @@ use RuntimeException;
  * @since 1.0
  */
 abstract class AbstractComponent implements NestableInterface {
-	/**
-	 * Holds a reference of the component's attribute manger.
-	 *
-	 * @var AttributeManager $attributeManager
-	 */
-	private $attributeManager;
-
-	/**
-	 * @var ComponentLibrary $componentLibrary
-	 */
-	private $componentLibrary;
+	private AttributeManager $attributeManager;
 
 	/**
 	 * The (html) id of this component. Not available before the component was opened.
-	 *
-	 * @var string $id
 	 */
-	private $id;
+	private ?string $id = null;
 
-	private $name;
+	private string $name;
 
-	/**
-	 * @var NestingController $nestingController
-	 */
-	private $nestingController;
+	private NestableInterface|false|null $parentComponent;
 
-	/**
-	 * @var NestableInterface|false $parentComponent
-	 */
-	private $parentComponent;
-
-	/**
-	 * @var ParserOutputHelper $parserOutputHelper
-	 */
-	private $parserOutputHelper;
-
-	/**
-	 * @var ParserRequest $parserRequest
-	 */
-	private $parserRequest;
+	private ?ParserRequest $parserRequest = null;
 
 	/**
 	 * For every of my registered attributes holds a value. false, if not valid in supplied
 	 * parserRequest.
-	 *
-	 * @var array $sanitizedAttributes
 	 */
-	private $sanitizedAttributes;
+	private array $sanitizedAttributes = [];
 
 	/**
 	 * Does the actual work in the individual components.
@@ -98,16 +68,13 @@ abstract class AbstractComponent implements NestableInterface {
 	/**
 	 * Component constructor.
 	 *
-	 * @param ComponentLibrary   $componentLibrary
-	 * @param ParserOutputHelper $parserOutputHelper
-	 * @param NestingController  $nestingController
-	 *
 	 * @throws RuntimeException cascading {@see ComponentLibrary::getNameFor} or {@see Component::extractAttribute}
 	 */
-	public function __construct( $componentLibrary, $parserOutputHelper, $nestingController ) {
-		$this->componentLibrary = $componentLibrary;
-		$this->parserOutputHelper = $parserOutputHelper;
-		$this->nestingController = $nestingController;
+	public function __construct(
+		private ComponentLibrary $componentLibrary,
+		private ParserOutputHelper $parserOutputHelper,
+		private NestingController $nestingController,
+	) {
 		$this->name = $componentLibrary->getNameFor(
 			get_class( $this )
 		);

--- a/src/AbstractComponent.php
+++ b/src/AbstractComponent.php
@@ -37,16 +37,16 @@ use RuntimeException;
  * @since 1.0
  */
 abstract class AbstractComponent implements NestableInterface {
-	private AttributeManager $attributeManager;
+	private readonly AttributeManager $attributeManager;
 
 	/**
 	 * The (html) id of this component. Not available before the component was opened.
 	 */
 	private ?string $id = null;
 
-	private string $name;
+	private readonly string $name;
 
-	private NestableInterface|false|null $parentComponent;
+	private readonly NestableInterface|false|null $parentComponent;
 
 	private ?ParserRequest $parserRequest = null;
 
@@ -71,9 +71,9 @@ abstract class AbstractComponent implements NestableInterface {
 	 * @throws RuntimeException cascading {@see ComponentLibrary::getNameFor} or {@see Component::extractAttribute}
 	 */
 	public function __construct(
-		private ComponentLibrary $componentLibrary,
-		private ParserOutputHelper $parserOutputHelper,
-		private NestingController $nestingController,
+		private readonly ComponentLibrary $componentLibrary,
+		private readonly ParserOutputHelper $parserOutputHelper,
+		private readonly NestingController $nestingController,
 	) {
 		$this->name = $componentLibrary->getNameFor(
 			get_class( $this )

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -40,9 +40,6 @@ use ReflectionClass;
  */
 class ApplicationFactory {
 
-	/**
-	 * @var ApplicationFactory $instance
-	 */
 	private static $instance = null;
 
 	/**

--- a/src/BootstrapComponents.php
+++ b/src/BootstrapComponents.php
@@ -55,9 +55,6 @@ use RuntimeException;
  */
 class BootstrapComponents {
 
-	/**
-	 * @var string $version
-	 */
 	private static string $version;
 
 	/**

--- a/src/BootstrapComponentsService.php
+++ b/src/BootstrapComponentsService.php
@@ -20,7 +20,7 @@ class BootstrapComponentsService
 	 */
 	private string $nameOfActiveSkin;
 
-	public function __construct( private Config $mainConfig ) {
+	public function __construct( private readonly Config $mainConfig ) {
 	}
 
 

--- a/src/BootstrapComponentsService.php
+++ b/src/BootstrapComponentsService.php
@@ -15,14 +15,8 @@ class BootstrapComponentsService
 	 */
 	private array $activeComponents;
 
-	/**
-	 * @var Config
-	 */
 	private Config $mainConfig;
 
-	/**
-	 * @var bool
-	 */
 	private bool $modalsSuppressedByMagicWord;
 
 	/**

--- a/src/BootstrapComponentsService.php
+++ b/src/BootstrapComponentsService.php
@@ -10,26 +10,17 @@ class BootstrapComponentsService
 
 	/**
 	 * List of active components on the page
-	 *
-	 * @var array $activeComponents
 	 */
-	private array $activeComponents;
+	private array $activeComponents = [];
 
-	private Config $mainConfig;
-
-	private bool $modalsSuppressedByMagicWord;
+	private bool $modalsSuppressedByMagicWord = false;
 
 	/**
 	 * Holds the name of the skin we use (or false, if there is no skin).
-	 *
-	 * @var string $nameOfActiveSkin
 	 */
 	private string $nameOfActiveSkin;
 
-	public function __construct( Config $mainConfig ) {
-		$this->mainConfig = $mainConfig;
-		$this->activeComponents = [];
-		$this->modalsSuppressedByMagicWord = false;
+	public function __construct( private Config $mainConfig ) {
 	}
 
 

--- a/src/ComponentLibrary.php
+++ b/src/ComponentLibrary.php
@@ -80,15 +80,13 @@ class ComponentLibrary {
 	 *      ]
 	 *  ]
 	 * </pre>
-	 *
-	 * @var array $componentDataStore
 	 */
 	private array $componentDataStore;
 
 	/**
-	 * The list of registered/allowed bootstrap components, name or alias
+	 * The list of registered/allowed bootstrap components, name or alias.
 	 *
-	 * @var string[] $registeredComponents
+	 * @var string[]
 	 */
 	private array $registeredComponents;
 

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -50,13 +50,13 @@ class Card extends AbstractComponent {
 	/**
 	 * Card constructor.
 	 *
-	 * @param ComponentLibrary   $componentLibrary
-	 * @param ParserOutputHelper $parserOutputHelper
-	 * @param NestingController  $nestingController
-	 *
 	 * @throws RuntimeException
 	 */
-	public function __construct( $componentLibrary, $parserOutputHelper, $nestingController ) {
+	public function __construct(
+		ComponentLibrary $componentLibrary,
+		ParserOutputHelper $parserOutputHelper,
+		NestingController $nestingController,
+	) {
 		parent::__construct( $componentLibrary, $parserOutputHelper, $nestingController );
 		$this->collapsible = false;
 		$parent = $this->getParentComponent();

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -43,18 +43,8 @@ use RuntimeException;
  */
 class Card extends AbstractComponent {
 
-	/**
-	 * Indicates, whether this panel is collapsible
-	 *
-	 * @var bool $collapsible
-	 */
 	private bool $collapsible;
 
-	/**
-	 * If true, indicates that we are inside an accordion
-	 *
-	 * @var bool $insideAccordion
-	 */
 	private bool $insideAccordion;
 
 	/**

--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -40,14 +40,8 @@ use MediaWiki\Output\OutputPage;
  */
 class OutputPageParserOutput {
 
-	/**
-	 * @var BootstrapComponentsService
-	 */
 	private BootstrapComponentsService $bootstrapComponentService;
 
-	/**
-	 * @var OutputPage $outputPage
-	 */
 	private OutputPage $outputPage;
 
 	/**

--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -40,17 +40,10 @@ use MediaWiki\Output\OutputPage;
  */
 class OutputPageParserOutput {
 
-	private BootstrapComponentsService $bootstrapComponentService;
-
-	private OutputPage $outputPage;
-
-	/**
-	 * @param OutputPage $outputPage
-	 * @param BootstrapComponentsService $service
-	 */
-	public function __construct( OutputPage &$outputPage, BootstrapComponentsService $service ) {
-		$this->outputPage = $outputPage;
-		$this->bootstrapComponentService = $service;
+	public function __construct(
+		private OutputPage $outputPage,
+		private BootstrapComponentsService $bootstrapComponentService,
+	) {
 	}
 
 	/**

--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -41,8 +41,8 @@ use MediaWiki\Output\OutputPage;
 class OutputPageParserOutput {
 
 	public function __construct(
-		private OutputPage $outputPage,
-		private BootstrapComponentsService $bootstrapComponentService,
+		private readonly OutputPage $outputPage,
+		private readonly BootstrapComponentsService $bootstrapComponentService,
 	) {
 	}
 

--- a/src/Hooks/ParserFirstCallInit.php
+++ b/src/Hooks/ParserFirstCallInit.php
@@ -45,39 +45,18 @@ use ReflectionClass;
  */
 class ParserFirstCallInit {
 
-	/**
-	 * @var ComponentLibrary $componentLibrary
-	 */
-	private $componentLibrary;
-
-	/**
-	 * @var NestingController $nestingController
-	 */
-	private $nestingController;
-
-	/**
-	 * @var Parser $parser
-	 */
-	private $parser;
-
-	/**
-	 * @var ParserOutputHelper $parserOutputHelper
-	 */
-	private $parserOutputHelper;
+	private ParserOutputHelper $parserOutputHelper;
 
 	/**
 	 * ParserFirstCallInit constructor.
 	 *
-	 * @param Parser            $parser
-	 * @param ComponentLibrary  $componentLibrary
-	 * @param NestingController $nestingController
-	 *
 	 * @throws RuntimeException  cascading {@see \BootstrapComponents\ApplicationFactory::getParserOutputHelper}
 	 */
-	public function __construct( $parser, $componentLibrary, $nestingController ) {
-		$this->componentLibrary = $componentLibrary;
-		$this->nestingController = $nestingController;
-		$this->parser = $parser;
+	public function __construct(
+		private Parser $parser,
+		private ComponentLibrary $componentLibrary,
+		private NestingController $nestingController,
+	) {
 		$this->parserOutputHelper = ApplicationFactory::getInstance()->getParserOutputHelper( $parser );
 	}
 

--- a/src/Hooks/ParserFirstCallInit.php
+++ b/src/Hooks/ParserFirstCallInit.php
@@ -45,7 +45,7 @@ use ReflectionClass;
  */
 class ParserFirstCallInit {
 
-	private ParserOutputHelper $parserOutputHelper;
+	private readonly ParserOutputHelper $parserOutputHelper;
 
 	/**
 	 * ParserFirstCallInit constructor.
@@ -53,9 +53,9 @@ class ParserFirstCallInit {
 	 * @throws RuntimeException  cascading {@see \BootstrapComponents\ApplicationFactory::getParserOutputHelper}
 	 */
 	public function __construct(
-		private Parser $parser,
-		private ComponentLibrary $componentLibrary,
-		private NestingController $nestingController,
+		private readonly Parser $parser,
+		private readonly ComponentLibrary $componentLibrary,
+		private readonly NestingController $nestingController,
 	) {
 		$this->parserOutputHelper = ApplicationFactory::getInstance()->getParserOutputHelper( $parser );
 	}

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -45,24 +45,12 @@ class HooksHandler implements
 	ParserFirstCallInitHook,
 	SetupAfterCacheHook
 {
-	/**
-	 * @var Config
-	 */
 	private Config $config;
 
-	/**
-	 * @var BootstrapComponentsService
-	 */
 	private BootstrapComponentsService $bootstrapComponentsService;
 
-	/**
-	 * @var ComponentLibrary
-	 */
 	private ComponentLibrary $componentLibrary;
 
-	/**
-	 * @var NestingController
-	 */
 	private NestingController $nestingController;
 
 	public function __construct(

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -48,9 +48,9 @@ class HooksHandler implements
 	private Config $config;
 
 	public function __construct(
-		private BootstrapComponentsService $bootstrapComponentsService,
-		private ComponentLibrary $componentLibrary,
-		private NestingController $nestingController,
+		private readonly BootstrapComponentsService $bootstrapComponentsService,
+		private readonly ComponentLibrary $componentLibrary,
+		private readonly NestingController $nestingController,
 	) {
 	}
 

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -121,7 +121,8 @@ class HooksHandler implements
 			if ( !$file ) {
 				return true;
 			}
-			$imageModal = new ImageModal( $linker, $title, $file,
+			$imageModal = new ImageModal(
+				$title, $file,
 				$this->getNestingController(), $this->getBootstrapComponentsService()
 			);
 

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -47,19 +47,11 @@ class HooksHandler implements
 {
 	private Config $config;
 
-	private BootstrapComponentsService $bootstrapComponentsService;
-
-	private ComponentLibrary $componentLibrary;
-
-	private NestingController $nestingController;
-
 	public function __construct(
-		BootstrapComponentsService $bootstrapComponentsService, ComponentLibrary $componentLibrary,
-		NestingController $nestingController
+		private BootstrapComponentsService $bootstrapComponentsService,
+		private ComponentLibrary $componentLibrary,
+		private NestingController $nestingController,
 	) {
-		$this->bootstrapComponentsService = $bootstrapComponentsService;
-		$this->componentLibrary = $componentLibrary;
-		$this->nestingController = $nestingController;
 	}
 
 	/**

--- a/src/ImageModal.php
+++ b/src/ImageModal.php
@@ -48,11 +48,11 @@ class ImageModal implements NestableInterface {
 	 */
 	const PARENTS_PREVENTING_MODAL = [ 'button', 'collapse ', 'image_modal', 'modal', 'popover', 'tooltip' ];
 
-	private null|string $id;
+	private readonly null|string $id;
 
-	private null|bool|NestableInterface $parentComponent;
+	private readonly null|bool|NestableInterface $parentComponent;
 
-	private ParserOutputHelper $parserOutputHelper;
+	private readonly ParserOutputHelper $parserOutputHelper;
 
 	private bool $disableSourceLink = false;
 

--- a/src/ImageModal.php
+++ b/src/ImageModal.php
@@ -59,13 +59,11 @@ class ImageModal implements NestableInterface {
 	/**
 	 * ImageModal constructor.
 	 *
-	 * @param null $null (was DummyLinker $dummyLinker)
 	 * @param ParserOutputHelper|null $parserOutputHelper DI for unit testing
 	 *
 	 * @throws RuntimeException cascading {@see ApplicationFactory} methods
 	 */
 	public function __construct(
-		$null,
 		private Title $title,
 		private File $file,
 		private NestingController $nestingController,

--- a/src/ImageModal.php
+++ b/src/ImageModal.php
@@ -48,44 +48,30 @@ class ImageModal implements NestableInterface {
 	 */
 	const PARENTS_PREVENTING_MODAL = [ 'button', 'collapse ', 'image_modal', 'modal', 'popover', 'tooltip' ];
 
-	private BootstrapComponentsService $bootstrapComponentService;
-
-	private File $file;
-
 	private null|string $id;
-
-	private NestingController $nestingController;
 
 	private null|bool|NestableInterface $parentComponent;
 
 	private ParserOutputHelper $parserOutputHelper;
 
-	private bool $disableSourceLink;
-
-	private Title $title;
+	private bool $disableSourceLink = false;
 
 	/**
 	 * ImageModal constructor.
 	 *
 	 * @param null $null (was DummyLinker $dummyLinker)
-	 * @param Title $title
-	 * @param File $file
-	 * @param NestingController $nestingController
-	 * @param BootstrapComponentsService $bootstrapComponentService
 	 * @param ParserOutputHelper|null $parserOutputHelper DI for unit testing
 	 *
 	 * @throws RuntimeException cascading {@see ApplicationFactory} methods
 	 */
 	public function __construct(
-		$null, Title $title, File $file,
-		NestingController $nestingController, BootstrapComponentsService $bootstrapComponentService,
-		ParserOutputHelper $parserOutputHelper = null
+		$null,
+		private Title $title,
+		private File $file,
+		private NestingController $nestingController,
+		private BootstrapComponentsService $bootstrapComponentService,
+		ParserOutputHelper $parserOutputHelper = null,
 	) {
-		$this->file = $file;
-		$this->title = $title;
-
-		$this->nestingController = $nestingController;
-		$this->bootstrapComponentService = $bootstrapComponentService;
 		$this->parserOutputHelper = $parserOutputHelper
 			?? ApplicationFactory::getInstance()->getParserOutputHelper();
 
@@ -93,7 +79,6 @@ class ImageModal implements NestableInterface {
 		$this->id = $this->getNestingController()->generateUniqueId(
 			$this->getComponentName()
 		);
-		$this->disableSourceLink = false;
 	}
 
 	/**

--- a/src/ImageModal.php
+++ b/src/ImageModal.php
@@ -48,44 +48,20 @@ class ImageModal implements NestableInterface {
 	 */
 	const PARENTS_PREVENTING_MODAL = [ 'button', 'collapse ', 'image_modal', 'modal', 'popover', 'tooltip' ];
 
-	/**
-	 * @var BootstrapComponentsService
-	 */
 	private BootstrapComponentsService $bootstrapComponentService;
 
-	/**
-	 * @var File $file
-	 */
 	private File $file;
 
-	/**
-	 * @var null|string $id
-	 */
 	private null|string $id;
 
-	/**
-	 * @var NestingController $nestingController
-	 */
 	private NestingController $nestingController;
 
-	/**
-	 * @var null|bool|NestableInterface $parentComponent
-	 */
 	private null|bool|NestableInterface $parentComponent;
 
-	/**
-	 * @var ParserOutputHelper $parserOutputHelper
-	 */
 	private ParserOutputHelper $parserOutputHelper;
 
-	/**
-	 * @var bool $disableSourceLink
-	 */
 	private bool $disableSourceLink;
 
-	/**
-	 * @var Title $title
-	 */
 	private Title $title;
 
 	/**

--- a/src/ImageModalTrigger.php
+++ b/src/ImageModalTrigger.php
@@ -43,8 +43,8 @@ use MediaWiki\Title\Title;
  */
 class ImageModalTrigger {
 	public function __construct(
-		private string $id,
-		private File $file,
+		private readonly string $id,
+		private readonly File $file,
 	) {
 	}
 

--- a/src/ImageModalTrigger.php
+++ b/src/ImageModalTrigger.php
@@ -26,14 +26,15 @@
 
 namespace MediaWiki\Extension\BootstrapComponents;
 
+use Exception;
+use File;
 use MediaWiki\Config\Config;
 use MediaWiki\Config\ConfigException;
-use Exception;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Html\Html;
 use MediaWiki\Linker\Linker;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
-use MediaWiki\Context\RequestContext;
 
 /**
  * Class ImageModal
@@ -41,25 +42,10 @@ use MediaWiki\Context\RequestContext;
  * @since 1.0
  */
 class ImageModalTrigger {
-	/**
-	 * @var \File $file
-	 */
-	private $file;
-
-	/**
-	 * @var string $id
-	 */
-	private $id;
-
-	/**
-	 * ImageModal constructor.
-	 *
-	 * @param string $id
-	 * @param \File  $file
-	 */
-	public function __construct( $id, $file ) {
-		$this->id = $id;
-		$this->file = $file;
+	public function __construct(
+		private string $id,
+		private File $file,
+	) {
 	}
 
 	/**

--- a/src/LuaLibrary.php
+++ b/src/LuaLibrary.php
@@ -42,14 +42,8 @@ use ReflectionException;
  */
 class LuaLibrary extends LibraryBase {
 
-	/**
-	 * @var ApplicationFactory $applicationFactory;
-	 */
 	private ApplicationFactory $applicationFactory;
 
-	/**
-	 * @var BootstrapComponentsService
-	 */
 	private BootstrapComponentsService $bootstrapComponentService;
 
 	/**

--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -50,11 +50,6 @@ use MediaWiki\Html\Html;
 class ModalBuilder {
 
 	/**
-	 * @var string $content
-	 */
-	private $content;
-
-	/**
 	 * @var string|false $footer
 	 */
 	private $footer;
@@ -63,11 +58,6 @@ class ModalBuilder {
 	 * @var string|false $header
 	 */
 	private $header;
-
-	/**
-	 * @var string $id
-	 */
-	private $id;
 
 	/**
 	 * @var string|false $bodyClass
@@ -98,11 +88,6 @@ class ModalBuilder {
 	 * @var string|false $outerStyle
 	 */
 	private $outerStyle;
-
-	/**
-	 * @var string $trigger
-	 */
-	private $trigger;
 
 	/**
 	 * With this, you can wrap a generic trigger element inside a span block, that hopefully should
@@ -137,17 +122,24 @@ class ModalBuilder {
 	 * Do not instantiate directly, but use {@see ApplicationFactory::getNewModalBuilder}
 	 * instead.
 	 *
-	 * @param string $id
 	 * @param string $trigger must be safe raw html (best run through {@see Parser::recursiveTagParse})
 	 * @param string $content must be fully parsed html (use {@see Parser::recursiveTagParseFully})
 	 *
 	 * @see ApplicationFactory::getNewModalBuilder
 	 * @see Components\Modal::generateButton
 	 */
-	public function __construct( $id, $trigger, $content ) {
-		$this->id = $id;
-		$this->trigger = $trigger;
-		$this->content = $content;
+	public function __construct(
+<<<<<<< HEAD
+		private string $id,
+		private string $trigger,
+		/** must be safe raw html (best run through {@see Parser::recursiveTagParse}) */
+		private string $content,
+=======
+		private readonly string $id,
+		private readonly string $trigger,
+		private readonly string $content,
+>>>>>>> 0490673 (Move ModalBuilder ctor param descriptions back into the docblock)
+	) {
 	}
 
 	/**

--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -129,16 +129,9 @@ class ModalBuilder {
 	 * @see Components\Modal::generateButton
 	 */
 	public function __construct(
-<<<<<<< HEAD
-		private string $id,
-		private string $trigger,
-		/** must be safe raw html (best run through {@see Parser::recursiveTagParse}) */
-		private string $content,
-=======
 		private readonly string $id,
 		private readonly string $trigger,
 		private readonly string $content,
->>>>>>> 0490673 (Move ModalBuilder ctor param descriptions back into the docblock)
 	) {
 	}
 

--- a/src/NestingController.php
+++ b/src/NestingController.php
@@ -41,8 +41,6 @@ class NestingController {
 	/**
 	 * List of ids already in use in the context of the bootstrap components.
 	 * Key is of this array is the component name, value is the next usable id.
-	 *
-	 * @var array $autoincrementPerComponent
 	 */
 	private array $autoincrementPerComponent;
 
@@ -51,8 +49,6 @@ class NestingController {
 	 * can get information about their parent "nest".
 	 *
 	 * Consists of elements of type {@see Nestable}.
-	 *
-	 * @var array $componentStack
 	 */
 	private array $componentStack;
 

--- a/src/ParserOutputHelper.php
+++ b/src/ParserOutputHelper.php
@@ -44,37 +44,22 @@ class ParserOutputHelper {
 
 	/**
 	 * To make sure, we only add the tracking category once.
-	 *
-	 * @var bool $articleTracked
 	 */
-	private $articleTracked;
+	private bool $articleTracked = false;
 
 	/**
 	 * To make sure, we only add the error tracking category once.
-	 *
-	 * @var bool $articleTrackedOnError
 	 */
-	private $articleTrackedOnError;
-
-	/**
-	 * @var Parser $parser
-	 */
-	private $parser;
-
+	private bool $articleTrackedOnError = false;
 
 	/**
 	 * ParserOutputHelper constructor.
 	 *
 	 * Do not instantiate directly, but use {@see ApplicationFactory::getParserOutputHelper} instead.
 	 *
-	 * @param Parser $parser
-	 *
 	 * @see ApplicationFactory::getParserOutputHelper
 	 */
-	public function __construct( $parser ) {
-		$this->articleTracked = false;
-		$this->articleTrackedOnError = false;
-		$this->parser = $parser;
+	public function __construct( private Parser $parser ) {
 	}
 
 	/**

--- a/src/ParserOutputHelper.php
+++ b/src/ParserOutputHelper.php
@@ -59,7 +59,7 @@ class ParserOutputHelper {
 	 *
 	 * @see ApplicationFactory::getParserOutputHelper
 	 */
-	public function __construct( private Parser $parser ) {
+	public function __construct( private readonly Parser $parser ) {
 	}
 
 	/**

--- a/src/ParserRequest.php
+++ b/src/ParserRequest.php
@@ -38,24 +38,13 @@ use PPFrame;
  * @since 1.0
  */
 class ParserRequest {
-	/**
-	 * @var string[] $attributes
-	 */
+	/** @var string[] */
 	private array $attributes;
 
-	/**
-	 * @var string $input
-	 */
 	private string $input;
 
-	/**
-	 * @var PPFrame|null $frame
-	 */
 	private PPFrame|null $frame;
 
-	/**
-	 * @var Parser $parser
-	 */
 	private Parser $parser;
 
 	/**

--- a/tests/phpunit/Fixtures/TestConfig.php
+++ b/tests/phpunit/Fixtures/TestConfig.php
@@ -11,14 +11,8 @@ use Traversable;
 
 class TestConfig implements Config, MutableConfig, IterableConfig
 {
-	/**
-	 * @var array
-	 */
 	private array $settings;
 
-	/**
-	 * @var array
-	 */
 	private array $originalSetting;
 
 	public function __construct( $prefix = 'wg' ) {

--- a/tests/phpunit/Unit/ComponentsTestBase.php
+++ b/tests/phpunit/Unit/ComponentsTestBase.php
@@ -30,9 +30,6 @@ abstract class ComponentsTestBase extends TestCase {
 	 */
 	private $frame;
 
-	/**
-	 * @var NestingController
-	 */
 	private NestingController $nestingController;
 
 	/**

--- a/tests/phpunit/Unit/Hooks/ParserFirstCallInitTest.php
+++ b/tests/phpunit/Unit/Hooks/ParserFirstCallInitTest.php
@@ -4,6 +4,7 @@ namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Hooks;
 
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\Hooks\ParserFirstCallInit;
+use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
 
@@ -75,9 +76,7 @@ class ParserFirstCallInitTest extends TestCase {
 				[ $this->equalTo( $prefix . 'well' ), $this->callback( 'is_callable' ) ]
 			);
 		$componentLibrary = new ComponentLibrary( true );
-		$nestingController = $this->getMockBuilder( 'BootstrapComponents\NestingController' )
-			->disableOriginalConstructor()
-			->getMock();
+		$nestingController = $this->createMock( NestingController::class );
 
 		/** @noinspection PhpParamsInspection */
 		$instance = new ParserFirstCallInit( $observerParser, $componentLibrary, $nestingController );

--- a/tests/phpunit/Unit/ImageModalTest.php
+++ b/tests/phpunit/Unit/ImageModalTest.php
@@ -46,7 +46,7 @@ class ImageModalTest extends TestCase {
 		);
 		$this->assertInstanceOf(
 			ImageModal::class,
-			$this->createImageModalWithMocks( null, null, $file )
+			$this->createImageModalWithMocks( null, $file )
 		);
 	}
 
@@ -63,7 +63,7 @@ class ImageModalTest extends TestCase {
 			->method( 'exists' )
 			->willReturn( false );
 
-		$instance = $this->createImageModalWithMocks( null, null, $file );
+		$instance = $this->createImageModalWithMocks( null, $file );
 		$fp = [];
 		$hp = [];
 		$time = false;
@@ -89,7 +89,7 @@ class ImageModalTest extends TestCase {
 			->method( 'exists' )
 			->willReturn( true );
 
-		$instance = $this->createImageModalWithMocks( null, null, $file );
+		$instance = $this->createImageModalWithMocks( null, $file );
 		$fp = [];
 		$hp = [];
 		$time = false;
@@ -117,7 +117,7 @@ class ImageModalTest extends TestCase {
 			->method( 'exists' )
 			->willReturn( true );
 
-		$instance = $this->createImageModalWithMocks( null, null, $file );
+		$instance = $this->createImageModalWithMocks( null, $file );
 		$time = false;
 		$res = '';
 		$fp =  [ 'manualthumb' => 'ImageInvalid.png' ];
@@ -177,7 +177,7 @@ class ImageModalTest extends TestCase {
 			->method( 'transform' )
 			->willReturn( $thumb );
 
-		$instance = $this->createImageModalWithMocks( null, $title, $file );
+		$instance = $this->createImageModalWithMocks( $title, $file );
 		$time = false;
 		$res = '';
 		$fp = [ 'align' => 'left' ]; # otherwise, this test produces an exception while trying to call $title->getPageLanguage()->alignEnd()
@@ -256,7 +256,7 @@ class ImageModalTest extends TestCase {
 
 		$parserOutputHelper = $this->createMock( ParserOutputHelper::class );
 
-		$instance = $this->createImageModalWithMocks( null, $title, $file, $nestingController, null, $parserOutputHelper );
+		$instance = $this->createImageModalWithMocks( $title, $file, $nestingController, null, $parserOutputHelper );
 		$time = false;
 		$res = '';
 
@@ -419,16 +419,15 @@ class ImageModalTest extends TestCase {
 	}
 
 	private function createImageModalWithMocks(
-		$dummyLinker = null, $title = null, $file = null, $nestingController = null,
+		$title = null, $file = null, $nestingController = null,
 		$bootstrapService = null, $parserOutputHelper = null
 	) {
-		$dummyLinker = null;
 		$title = $title ?? $this->createMock( Title::class );
 		$file = $file ?? $this->createMock( LocalFile::class );
 		$nestingController = $nestingController ?? $this->createMock( NestingController::class );
 		$bootstrapService = $bootstrapService ?? $this->createMock( BootstrapComponentsService::class );
 		$parserOutputHelper = $parserOutputHelper ?? $this->createMock( ParserOutputHelper::class );
 
-		return new ImageModal( $dummyLinker, $title, $file, $nestingController, $bootstrapService, $parserOutputHelper );
+		return new ImageModal( $title, $file, $nestingController, $bootstrapService, $parserOutputHelper );
 	}
 }

--- a/tests/phpunit/Unit/LuaLibraryTest.php
+++ b/tests/phpunit/Unit/LuaLibraryTest.php
@@ -18,8 +18,6 @@ class LuaLibraryTest extends LuaLibraryTestBase {
 
 	/**
 	 * Lua test module
-	 *
-	 * @var string
 	 */
 	protected static $moduleName = self::class;
 

--- a/tests/phpunit/Unit/ParserOutputHelperTest.php
+++ b/tests/phpunit/Unit/ParserOutputHelperTest.php
@@ -23,9 +23,6 @@ use PHPUnit\Framework\TestCase;
  * @author  Tobias Oetterer
  */
 class ParserOutputHelperTest extends TestCase {
-	/**
-	 * @var Parser
-	 */
 	private Parser $parser;
 
 	/**


### PR DESCRIPTION
Tighten the extension's PHP under the 8.1 baseline raised in #82,
ahead of the Bootstrap 5 migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
