### PR TITLE
Restore loading of vector-fix CSS modules

### DIFF
--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -226,7 +226,7 @@ class HooksHandler implements
 			if ( !$this->getComponentLibrary()->isRegistered( $activeComponent ) ) {
 				continue;
 			}
-			foreach ( $this->getComponentLibrary()->getModulesFor( $activeComponent ) as $module ) {
+			foreach ( $this->getComponentLibrary()->getModulesFor( $activeComponent, 'vector' ) as $module ) {
 				$parser->getOutput()->addModuleStyles( [ $module ] );
 				$parser->getOutput()->addModules( [ $module ] );
 			}

--- a/tests/phpunit/Unit/HooksHandlerTest.php
+++ b/tests/phpunit/Unit/HooksHandlerTest.php
@@ -6,8 +6,6 @@ use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\HooksHandler;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
-use Parser;
-use ParserOutput;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -75,49 +73,4 @@ class HooksHandlerTest extends TestCase {
 		$this->assertTrue( true );
 	}
 
-	public function testOnParserAfterParseLoadsActiveComponentScriptsAndStyles() {
-		$loadedStyles = [];
-		$loadedModules = [];
-
-		$parserOutput = $this->createMock( ParserOutput::class );
-		$parserOutput->method( 'addModuleStyles' )
-			->willReturnCallback( function ( $m ) use ( &$loadedStyles ) {
-				$loadedStyles = array_merge( $loadedStyles, (array)$m );
-			} );
-		$parserOutput->method( 'addModules' )
-			->willReturnCallback( function ( $m ) use ( &$loadedModules ) {
-				$loadedModules = array_merge( $loadedModules, (array)$m );
-			} );
-
-		$parser = $this->createMock( Parser::class );
-		$parser->method( 'getOutput' )->willReturn( $parserOutput );
-
-		$service = $this->createMock( BootstrapComponentsService::class );
-		$service->method( 'getNameOfActiveSkin' )->willReturn( 'vector' );
-		$service->method( 'getActiveComponents' )->willReturn( [ 'tooltip', 'popover' ] );
-
-		$library = $this->createMock( ComponentLibrary::class );
-		$library->method( 'isRegistered' )->willReturn( true );
-		$library->method( 'getModulesFor' )
-			->willReturnCallback( function ( $name ) {
-				return [ 'ext.bootstrapComponents.' . $name . '.fix' ];
-			} );
-
-		$handler = new HooksHandler(
-			$service,
-			$library,
-			$this->createMock( NestingController::class )
-		);
-
-		$text = '';
-		$handler->onParserAfterParse( $parser, $text, null );
-
-		// Per-component fix modules must reach BOTH addModuleStyles and addModules
-		// (style-only modules treat addModules as a no-op; modules with a scripts
-		// entry get their JS init via that call).
-		$this->assertContains( 'ext.bootstrapComponents.tooltip.fix', $loadedStyles );
-		$this->assertContains( 'ext.bootstrapComponents.popover.fix', $loadedStyles );
-		$this->assertContains( 'ext.bootstrapComponents.tooltip.fix', $loadedModules );
-		$this->assertContains( 'ext.bootstrapComponents.popover.fix', $loadedModules );
-	}
 }


### PR DESCRIPTION
Two commits, two concerns. Fixes #84.

### 1. Restore loading of vector-fix CSS modules — `af96510`

The replacement sparse-loading foreach added in #80 (`HooksHandler::onParserAfterParse`) called `getModulesFor( $activeComponent )` without a skin argument, returning only the `default` module group. The Vector-fix modules live in the `vector` group and were therefore silently dropped on every skin. Adding back `'vector'` reinstates the per-skin group that `AbstractComponent::augmentParserOutput()` had been passing since 5.2.0 (commit [f5a9c9f]) — the path that MW 1.43's `ParserOutputAccess` lifecycle change silently disabled, which is precisely what #80 set out to compensate for via the post-parse hook.

### 2. Drop heavy mock-based test for the post-parse module loader — `c0ac01b`

Per [Jeroen's review on #80][jeroen-80-review], the test that landed alongside the sparse-loading patch pinned a single argument literal through deep mocks of every collaborator on `HooksHandler`, coupling to call signatures rather than behaviour. Integration verification on the running rig is the more reliable signal for this regression.

[f5a9c9f]: https://github.com/oetterer/BootstrapComponents/commit/f5a9c9f
[jeroen-80-review]: https://github.com/oetterer/BootstrapComponents/pull/80#pullrequestreview-4341362729
