### PR TITLE
Prepare release 5.2.4

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,12 @@
 ## Release Notes
 
+### BootstrapComponents 5.2.4
+
+Released on 22-May-2026
+
+Fixes:
+* fix modal backdrop displaying on top of modal content on Vector, Vector 2022, MonoBook, and Timeless skins on MediaWiki 1.43+
+
 ### BootstrapComponents 5.2.3
 
 Released on 21-May-2026

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "BootstrapComponents",
-	"version": "5.2.3",
+	"version": "5.2.4",
 	"author": [ "Tobias Oetterer" ],
 	"url": "https://www.mediawiki.org/wiki/Extension:BootstrapComponents",
 	"descriptionmsg": "bootstrap-components-desc",


### PR DESCRIPTION
Prepares the 5.2.4 patch release. Two commits matching the 5.2.3 release-prep pattern (#81):

1. **Update release notes** — add the 5.2.4 entry covering the fix from #85.
2. **Bump version** — `extension.json` `5.2.3` → `5.2.4`.

`Released on _TBD_` is intentional — fill in the actual date at tag time.

No code or test changes; purely the release-prep metadata. Once merged, tag `5.2.4` from the merge commit.

Closes #84 once tagged (already addressed by #85; this is the release that ships it).
