### PR TITLE
Restore loading of vector-fix CSS modules

### DIFF
--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -204,7 +204,7 @@ class HooksHandler implements
 			if ( !$this->getComponentLibrary()->isRegistered( $activeComponent ) ) {
 				continue;
 			}
-			foreach ( $this->getComponentLibrary()->getModulesFor( $activeComponent ) as $module ) {
+			foreach ( $this->getComponentLibrary()->getModulesFor( $activeComponent, 'vector' ) as $module ) {
 				$parser->getOutput()->addModuleStyles( [ $module ] );
 				$parser->getOutput()->addModules( [ $module ] );
 			}

--- a/tests/phpunit/Unit/HooksHandlerTest.php
+++ b/tests/phpunit/Unit/HooksHandlerTest.php
@@ -6,8 +6,6 @@ use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\HooksHandler;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
-use MediaWiki\Parser\Parser;
-use MediaWiki\Parser\ParserOutput;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -73,51 +71,5 @@ class HooksHandlerTest extends TestCase {
 	 */
 	public function testOnOutputPageParserOutput() {
 		$this->assertTrue( true );
-	}
-
-	public function testOnParserAfterParseLoadsActiveComponentScriptsAndStyles() {
-		$loadedStyles = [];
-		$loadedModules = [];
-
-		$parserOutput = $this->createMock( ParserOutput::class );
-		$parserOutput->method( 'addModuleStyles' )
-			->willReturnCallback( function ( $m ) use ( &$loadedStyles ) {
-				$loadedStyles = array_merge( $loadedStyles, (array)$m );
-			} );
-		$parserOutput->method( 'addModules' )
-			->willReturnCallback( function ( $m ) use ( &$loadedModules ) {
-				$loadedModules = array_merge( $loadedModules, (array)$m );
-			} );
-
-		$parser = $this->createMock( Parser::class );
-		$parser->method( 'getOutput' )->willReturn( $parserOutput );
-
-		$service = $this->createMock( BootstrapComponentsService::class );
-		$service->method( 'getNameOfActiveSkin' )->willReturn( 'vector' );
-		$service->method( 'getActiveComponents' )->willReturn( [ 'tooltip', 'popover' ] );
-
-		$library = $this->createMock( ComponentLibrary::class );
-		$library->method( 'isRegistered' )->willReturn( true );
-		$library->method( 'getModulesFor' )
-			->willReturnCallback( function ( $name ) {
-				return [ 'ext.bootstrapComponents.' . $name . '.fix' ];
-			} );
-
-		$handler = new HooksHandler(
-			$service,
-			$library,
-			$this->createMock( NestingController::class )
-		);
-
-		$text = '';
-		$handler->onParserAfterParse( $parser, $text, null );
-
-		// Per-component fix modules must reach BOTH addModuleStyles and addModules
-		// (style-only modules treat addModules as a no-op; modules with a scripts
-		// entry get their JS init via that call).
-		$this->assertContains( 'ext.bootstrapComponents.tooltip.fix', $loadedStyles );
-		$this->assertContains( 'ext.bootstrapComponents.popover.fix', $loadedStyles );
-		$this->assertContains( 'ext.bootstrapComponents.tooltip.fix', $loadedModules );
-		$this->assertContains( 'ext.bootstrapComponents.popover.fix', $loadedModules );
 	}
 }


### PR DESCRIPTION
Cross-port of #85 from the 5.x maintenance branch.

The same broken foreach pattern exists on master at `src/HooksHandler.php:207`: `getModulesFor( $activeComponent )` without a skin argument, so the per-skin Vector-fix modules never reach any skin on MW 1.43+. Same one-line fix; same brittle mock test removal (per [Jeroen's review on #80][jeroen-80-review]).

This unblocks the next major release shipping with the same modal-backdrop bug that #85 fixes for 5.2.4. Manually verified on the rig with BC 5.2.3 + Bootstrap-ext 5.0.0; the fix's mechanism is BS-version-independent and applies identically on the master / Bootstrap 5 line.

Closes #84 (master is the v6 line that ships the principled redesign tracked under the new follow-up issue; this PR delivers the same patch-release workaround so master isn't left with a known issue while waiting for the redesign).

[jeroen-80-review]: https://github.com/oetterer/BootstrapComponents/pull/80#pullrequestreview-4341362729
