### PR TITLE
Sync 5.2.4 release notes onto master

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,13 @@ Breaking changes:
 * requires MediaWiki 1.43 or later
 * requires PHP 8.1 or later
 
+### BootstrapComponents 5.2.4
+
+Released on 22-May-2026
+
+Fixes:
+* fix modal backdrop displaying on top of modal content on Vector, Vector 2022, MonoBook, and Timeless skins on MediaWiki 1.43+
+
 ### BootstrapComponents 5.2.3
 
 Released on 21-May-2026


### PR DESCRIPTION
Brings master's release notes in line with the 5.2.4 tag: add the 5.2.4 historical entry between the 6.0.0 and 5.2.3 sections, mirroring how 5.2.3 was preserved in master's history.

The 6.0.0 section is left alone — the modal-backdrop fix is inherited from 5.2.4 (master is based on the 5.x line) and the 5.2.4 historical entry already documents it.

No code changes; docs only.
