### PR TITLE
Migrate to Bootstrap 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 	"require": {
 		"php": ">=8.1",
 		"composer/installers": "^2|^1.0.1",
-		"mediawiki/bootstrap": "^5.0"
+		"mediawiki/bootstrap": "^6.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "46.0.0",
@@ -58,5 +58,10 @@
 			"composer phpunit",
 			"composer cs"
 		]
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "6.x-dev"
+		}
 	}
 }

--- a/docs/components.md
+++ b/docs/components.md
@@ -22,6 +22,8 @@ the following components are available to be used inside the wiki text:
   want to hide and show large amount of content.
 * **[Jumbotron](components/jumbotron.md)**: A jumbotron indicates a big
   box for calling extra attention to some special content or information.
+  _Bootstrap 5 removed `.jumbotron`; the parser function is retained,
+  now emitting Bootstrap 5 utility classes for an equivalent look._
 * **[Modal](components/modal.md)**: The Modal component is a dialog
   box/popup window that is displayed on top of the current page.
 * **[Popover](components/popover.md)**: The Popover component produces a

--- a/docs/components/accordion.md
+++ b/docs/components/accordion.md
@@ -40,6 +40,5 @@ add multiple css styles, separate them by a semicolon.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/collapse/#accordion-example
-* https://www.w3schools.com/bootstrap4/bootstrap_collapse.asp
+* https://getbootstrap.com/docs/5.3/components/accordion/
 

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -54,6 +54,5 @@ add multiple css styles, separate them by a semicolon.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/alerts/
-* https://www.w3schools.com/bootstrap4/bootstrap_alerts.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/components/alerts/
+* https://getbootstrap.com/docs/5.3/utilities/colors/

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -52,7 +52,6 @@ add multiple css styles, separate them by a semicolon.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/badge/
-* https://www.w3schools.com/bootstrap4/bootstrap_badges.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/components/badge/
+* https://getbootstrap.com/docs/5.3/utilities/colors/
 *

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -78,7 +78,6 @@ background with button color.</dd>
 
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/buttons/
-* https://www.w3schools.com/bootstrap4/bootstrap_buttons.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/components/buttons/
+* https://getbootstrap.com/docs/5.3/utilities/colors/
 *

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -109,6 +109,5 @@ add multiple css styles, separate them by a semicolon.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/card/
-* https://www.w3schools.com/bootstrap4/bootstrap_cards.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/components/card/
+* https://getbootstrap.com/docs/5.3/utilities/colors/

--- a/docs/components/carousel.md
+++ b/docs/components/carousel.md
@@ -38,5 +38,4 @@ attributes, otherwise the parser will drop all but one:
 ```
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/carousel/
-* https://www.w3schools.com/bootstrap4/bootstrap_carousel.asp
+* https://getbootstrap.com/docs/5.3/components/carousel/

--- a/docs/components/collapse.md
+++ b/docs/components/collapse.md
@@ -29,5 +29,4 @@ be used as the trigger element. In this case, all but the attributes
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/collapse/
-* https://www.w3schools.com/bootstrap4/bootstrap_collapse.asp
+* https://getbootstrap.com/docs/5.3/components/collapse/

--- a/docs/components/jumbotron.md
+++ b/docs/components/jumbotron.md
@@ -1,9 +1,14 @@
 ## Jumbotron
+
+> **Note.** Bootstrap 5 removed the `.jumbotron` component. The
+> `bootstrap_jumbotron` parser function is retained for backward
+> compatibility and now emits the equivalent Bootstrap 5 utility-class
+> combination per the official migration guide linked below.
+
 A jumbotron indicates a big box for calling extra attention to some special
 content or information.
 
-A jumbotron is displayed as a grey box with rounded corners. It also enlarges
-the font sizes of the text inside it.
+A jumbotron is displayed as a grey box with rounded corners.
 
 See also:
 * [Alert](alert.md)
@@ -33,5 +38,5 @@ add multiple css styles, separate them by a semicolon.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/jumbotron/
-* https://www.w3schools.com/bootstrap4/bootstrap_jumbotron.asp
+* https://getbootstrap.com/docs/5.3/migration/#jumbotron
+* https://getbootstrap.com/docs/5.3/examples/jumbotron/

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -76,8 +76,7 @@ be used as the trigger element.</dd>
 </dl>
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/modal/
-* https://www.w3schools.com/bootstrap4/bootstrap_modal.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/components/modal/
+* https://getbootstrap.com/docs/5.3/utilities/colors/
 
 Please, see also the [known issues](../known-issues.md) with this component.

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -94,6 +94,5 @@ behaviour with:
 
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/popovers/
-* https://www.w3schools.com/bootstrap4/bootstrap_popover.asp
-* https://getbootstrap.com/docs/4.1/utilities/colors/
+* https://getbootstrap.com/docs/5.3/components/popovers/
+* https://getbootstrap.com/docs/5.3/utilities/colors/

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -51,5 +51,4 @@ following to your `Mediawiki:Common.css`:
 ```
 
 ### Links
-* https://getbootstrap.com/docs/4.1/components/tooltips/
-* https://www.w3schools.com/bootstrap4/bootstrap_tooltip.asp
+* https://getbootstrap.com/docs/5.3/components/tooltips/

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,6 +7,7 @@ Released on TBD
 Breaking changes:
 * requires MediaWiki 1.43 or later
 * requires PHP 8.1 or later
+* requires Bootstrap extension 6.x, which bundles Bootstrap library 5.3
 
 ### BootstrapComponents 5.2.4
 

--- a/extension.json
+++ b/extension.json
@@ -109,7 +109,9 @@
 			"scripts": "ext.bootstrapComponents.carousel.js"
 		},
 		"ext.bootstrapComponents.modal.fix": {
-			"styles": "ext.bootstrapComponents.modal.fix.css"
+			"dependencies": "ext.bootstrap.scripts",
+			"styles": "ext.bootstrapComponents.modal.fix.css",
+			"scripts": "ext.bootstrapComponents.modal.js"
 		},
 		"ext.bootstrapComponents.modal.vector-fix": {
 			"styles": "ext.bootstrapComponents.modal.vector-fix.css"

--- a/modules/ext.bootstrapComponents.carousel.fix.css
+++ b/modules/ext.bootstrapComponents.carousel.fix.css
@@ -30,6 +30,6 @@
     margin: auto;
 }
 
-.carousel ol.carousel-indicators {
+.carousel .carousel-indicators {
     margin: 0 0 10px -30%;
 }

--- a/modules/ext.bootstrapComponents.carousel.js
+++ b/modules/ext.bootstrapComponents.carousel.js
@@ -1,5 +1,5 @@
 /**
- * Contains javascript code executed when tooltips are used.
+ * Contains javascript code executed when carousels are used.
  *
  * @copyright (C) 2018, Tobias Oetterer, Paderborn University
  * @license       https://www.gnu.org/licenses/gpl-3.0.html GNU General Public License, version 3 (or later)
@@ -23,6 +23,25 @@
  * @author        Tobias Oetterer
  */
 
-$(function () {
-	$('.carousel').carousel();
-});
+( function () {
+	'use strict';
+
+	// Wait for DOM to be ready
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initCarousels );
+	} else {
+		initCarousels();
+	}
+
+	function initCarousels() {
+		if ( typeof bootstrap === 'undefined' || !bootstrap.Carousel ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'BootstrapComponents: bootstrap.Carousel is not available; carousels will not cycle.' );
+			return;
+		}
+		const carouselElements = document.querySelectorAll( '.carousel' );
+		carouselElements.forEach( function ( element ) {
+			new bootstrap.Carousel( element );
+		} );
+	}
+}() );

--- a/modules/ext.bootstrapComponents.modal.js
+++ b/modules/ext.bootstrapComponents.modal.js
@@ -1,0 +1,28 @@
+/**
+ * Contains javascript code executed when modals are used.
+ */
+
+( function () {
+	'use strict';
+
+	// Wait for DOM to be ready
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initModals );
+	} else {
+		initModals();
+	}
+
+	function initModals() {
+		if ( typeof bootstrap === 'undefined' || !bootstrap.Modal ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'BootstrapComponents: bootstrap.Modal is not available; modal triggers will not work.' );
+			return;
+		}
+		// Instantiate every .modal element so trigger clicks (or programmatic
+		// bootstrap.Modal.getOrCreateInstance(el).show()) work as expected.
+		const modalList = document.querySelectorAll( '.modal' );
+		modalList.forEach( function ( modalEl ) {
+			bootstrap.Modal.getOrCreateInstance( modalEl );
+		} );
+	}
+}() );

--- a/modules/ext.bootstrapComponents.popover.js
+++ b/modules/ext.bootstrapComponents.popover.js
@@ -22,11 +22,28 @@
  * @ingroup       BootstrapComponents
  * @author        Tobias Oetterer
  */
-$( function() {
-    $(document).ready(function(){
-            $('[data-toggle="popover"]').popover({
-                html: true
-            });
-        });
-    }
-);
+
+( function () {
+	'use strict';
+
+	// Wait for DOM to be ready
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initPopovers );
+	} else {
+		initPopovers();
+	}
+
+	function initPopovers() {
+		if ( typeof bootstrap === 'undefined' || !bootstrap.Popover ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'BootstrapComponents: bootstrap.Popover is not available; popover triggers will not work.' );
+			return;
+		}
+		const popoverTriggerList = document.querySelectorAll( '[data-bs-toggle="popover"]' );
+		popoverTriggerList.forEach( function ( popoverTriggerEl ) {
+			new bootstrap.Popover( popoverTriggerEl, {
+				html: true
+			} );
+		} );
+	}
+}() );

--- a/modules/ext.bootstrapComponents.tooltip.js
+++ b/modules/ext.bootstrapComponents.tooltip.js
@@ -23,9 +23,25 @@
  * @author        Tobias Oetterer
  */
 
-$( function() {
-    $(document).ready(function(){
-            $('[data-toggle="tooltip"]').tooltip();
-        });
-    }
-);
+( function () {
+	'use strict';
+
+	// Wait for DOM to be ready
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initTooltips );
+	} else {
+		initTooltips();
+	}
+
+	function initTooltips() {
+		if ( typeof bootstrap === 'undefined' || !bootstrap.Tooltip ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'BootstrapComponents: bootstrap.Tooltip is not available; tooltip triggers will not work.' );
+			return;
+		}
+		const tooltipTriggerList = document.querySelectorAll( '[data-bs-toggle="tooltip"]' );
+		tooltipTriggerList.forEach( function ( tooltipTriggerEl ) {
+			new bootstrap.Tooltip( tooltipTriggerEl );
+		} );
+	}
+}() );

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -109,18 +109,11 @@ class Alert extends AbstractComponent {
 		return Html::rawElement(
 			'button',
 			[
-				'type'         => 'button',
-				'class'        => 'close',
+				'type'            => 'button',
+				'class'           => 'btn-close',
 				'data-bs-dismiss' => 'alert',
-				'aria-label'   => wfMessage( 'bootstrap-components-close-element' )->inContentLanguage()->text(),
-			],
-			Html::rawElement(
-				'span',
-				[
-					'aria-hidden' => 'true',
-				],
-				'&times;'
-			)
+				'aria-label'      => wfMessage( 'bootstrap-components-close-element' )->inContentLanguage()->text(),
+			]
 		);
 	}
 }

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -111,7 +111,7 @@ class Alert extends AbstractComponent {
 			[
 				'type'         => 'button',
 				'class'        => 'close',
-				'data-dismiss' => 'alert',
+				'data-bs-dismiss' => 'alert',
 				'aria-label'   => wfMessage( 'bootstrap-components-close-element' )->inContentLanguage()->text(),
 			],
 			Html::rawElement(

--- a/src/Components/Badge.php
+++ b/src/Components/Badge.php
@@ -72,10 +72,10 @@ class Badge extends AbstractComponent {
 		$class = [ 'badge' ];
 
 		if ( (bool)$this->getValueFor( 'pill' ) ) {
-			$class[] = 'badge-pill';
+			$class[] = 'rounded-pill';
 		}
 
-		$class[] = 'badge-' . $this->getValueFor( 'color', 'primary' );
+		$class[] = 'text-bg-' . $this->getValueFor( 'color', 'primary' );
 		return $class;
 	}
 }

--- a/src/Components/Card.php
+++ b/src/Components/Card.php
@@ -83,7 +83,7 @@ class Card extends AbstractComponent {
 			'class' => $this->arrayToString( $innerClass, ' ' ),
 		];
 		if ( $this->isCollapsible() ) {
-			$innerAttributes['data-parent'] = $this->getDataParent();
+			$innerAttributes['data-bs-parent'] = $this->getDataParent();
 			$innerAttributes['aria-labelledby'] = $this->getId() . '_header';
 		}
 
@@ -240,8 +240,8 @@ class Card extends AbstractComponent {
 		if ( $type == 'header' ) {
 			if ( $this->isCollapsible() ) {
 				$newAttributes += [
-					'data-toggle'   => 'collapse',
-					'data-target'   => '#' . $this->getId(),
+					'data-bs-toggle'   => 'collapse',
+					'data-bs-target'   => '#' . $this->getId(),
 					'aria-controls' => $this->getId(),
 					'aria-expanded' => $this->getValueFor( 'active' ) ? 'true' : 'false',
 					'id'            => $this->getId() . '_header'

--- a/src/Components/Carousel.php
+++ b/src/Components/Carousel.php
@@ -63,7 +63,7 @@ class Carousel extends AbstractComponent {
 					'class'     => $this->arrayToString( $class, ' ' ),
 					'style'     => $this->arrayToString( $style, ';' ),
 					'id'        => $this->getId(),
-					'data-ride' => 'carousel',
+					'data-bs-ride' => 'carousel',
 				],
 				$this->generateIndicators( count( $images ) )
 				. Html::rawElement(
@@ -90,7 +90,7 @@ class Carousel extends AbstractComponent {
 					'class'      => 'carousel-control-prev',
 					'href'       => '#' . $this->getId(),
 					'role'       => 'button',
-					'data-slide' => 'prev',
+					'data-bs-slide' => 'prev',
 				],
 				Html::rawElement( 'span', [ 'class' => 'carousel-control-prev-icon', 'aria-hidden' => 'true' ] )
 			) . Html::rawElement(
@@ -99,7 +99,7 @@ class Carousel extends AbstractComponent {
 					'class'      => 'carousel-control-next',
 					'href'       => '#' . $this->getId(),
 					'role'       => 'button',
-					'data-slide' => 'next',
+					'data-bs-slide' => 'next',
 				],
 				Html::rawElement( 'span', [ 'class' => 'carousel-control-next-icon', 'aria-hidden' => 'true' ] )
 			);
@@ -188,8 +188,8 @@ class Carousel extends AbstractComponent {
 			$inner .= "\t" . Html::rawElement(
 					'li',
 					[
-						'data-target'   => '#' . $this->getId(),
-						'data-slide-to' => $i,
+						'data-bs-target'   => '#' . $this->getId(),
+						'data-bs-slide-to' => $i,
 						'class'         => $class,
 					]
 				) . PHP_EOL;

--- a/src/Components/Carousel.php
+++ b/src/Components/Carousel.php
@@ -186,17 +186,20 @@ class Carousel extends AbstractComponent {
 		$class = 'active';
 		for ( $i = 0; $i < $num; $i++ ) {
 			$inner .= "\t" . Html::rawElement(
-					'li',
+					'button',
 					[
+						'type'             => 'button',
 						'data-bs-target'   => '#' . $this->getId(),
 						'data-bs-slide-to' => $i,
-						'class'         => $class,
+						'class'            => $class ?: false,
+						'aria-current'     => $class ? 'true' : false,
+						'aria-label'       => 'Slide ' . ( $i + 1 ),
 					]
 				) . PHP_EOL;
 			$class = false;
 		}
 		return PHP_EOL . Html::rawElement(
-				'ol',
+				'div',
 				[ 'class' => 'carousel-indicators' ],
 				$inner
 			) . PHP_EOL;

--- a/src/Components/Collapse.php
+++ b/src/Components/Collapse.php
@@ -74,7 +74,7 @@ class Collapse extends AbstractComponent {
 	 */
 	private function generateButton( ParserRequest $parserRequest ) {
 		$button = new Button( $this->getComponentLibrary(), $this->getParserOutputHelper(), $this->getNestingController() );
-		$button->injectRawAttributes( [ 'data-toggle' => 'collapse' ] );
+		$button->injectRawAttributes( [ 'data-bs-toggle' => 'collapse' ] );
 
 		$buttonAttributes = $parserRequest->getAttributes();
 		unset( $buttonAttributes['id'] );

--- a/src/Components/Jumbotron.php
+++ b/src/Components/Jumbotron.php
@@ -44,7 +44,9 @@ class Jumbotron extends AbstractComponent {
 	 * @param string $input
 	 */
 	protected function placeMe( $input ) {
-		list ( $class, $style ) = $this->processCss( 'jumbotron', [] );
+		// Bootstrap 5 dropped `.jumbotron` in favour of composing the same look
+		// from utility classes. See https://getbootstrap.com/docs/5.3/examples/jumbotron/.
+		list ( $class, $style ) = $this->processCss( [ 'p-5', 'mb-4', 'bg-body-tertiary', 'rounded-3' ], [] );
 		# @hack: the outer container is a workaround, to get all the necessary css if not inside a grid container
 		# @fixme: used inside mw content, the width calculation for smaller screens is broken (as of Bootstrap 1.2.3)
 		return Html::rawElement(

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -106,8 +106,8 @@ class Modal extends AbstractComponent {
 			[
 				'type'        => 'button',
 				'class'       => 'modal-trigger btn btn-' . $this->getValueFor( 'color', 'default' ),
-				'data-toggle' => 'modal',
-				'data-target' => '#' . $this->getId(),
+				'data-bs-toggle' => 'modal',
+				'data-bs-target' => '#' . $this->getId(),
 			],
 			$text
 		);

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -104,8 +104,8 @@ class Modal extends AbstractComponent {
 		return Html::rawElement(
 			'button',
 			[
-				'type'        => 'button',
-				'class'       => 'modal-trigger btn btn-' . $this->getValueFor( 'color', 'default' ),
+				'type'           => 'button',
+				'class'          => 'modal-trigger btn btn-' . $this->getValueFor( 'color', 'default' ),
 				'data-bs-toggle' => 'modal',
 				'data-bs-target' => '#' . $this->getId(),
 			],

--- a/src/Components/Popover.php
+++ b/src/Components/Popover.php
@@ -87,11 +87,11 @@ class Popover extends AbstractComponent {
 			$attributes = array_merge(
 				$attributes,
 				[
-					'data-toggle'    => 'popover',
+					'data-bs-toggle'    => 'popover',
 					'title'          => $heading,
-					'data-content'   => str_replace( "\n", " ", trim( $input ) ),
-					'data-placement' => $this->getValueFor( 'placement' ),
-					'data-trigger'   => $this->getValueFor( 'trigger' ),
+					'data-bs-content'   => str_replace( "\n", " ", trim( $input ) ),
+					'data-bs-placement' => $this->getValueFor( 'placement' ),
+					'data-bs-trigger'   => $this->getValueFor( 'trigger' ),
 				]
 			);
 			$tag = "button";

--- a/src/Components/Tooltip.php
+++ b/src/Components/Tooltip.php
@@ -85,8 +85,8 @@ class Tooltip extends AbstractComponent {
 			$attributes = array_merge(
 				$attributes,
 				[
-					'data-placement' => $this->getValueFor( 'placement' ),
-					'data-toggle'    => 'tooltip',
+					'data-bs-placement' => $this->getValueFor( 'placement' ),
+					'data-bs-toggle'    => 'tooltip',
 					'title'          => $tooltip,
 				]
 			);

--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -447,10 +447,10 @@ class ModalBuilder {
 				$footer . Html::rawElement(
 					'button',
 					[
-						'type'         => 'button',
-						'class'        => 'btn btn-default',
+						'type'            => 'button',
+						'class'           => 'btn btn-default',
 						'data-bs-dismiss' => 'modal',
-						'aria-label'   => $close,
+						'aria-label'      => $close,
 					],
 					$close
 				)
@@ -477,16 +477,11 @@ class ModalBuilder {
 		$button = Html::rawElement(
 			'button',
 			[
-				'type'         => 'button',
-				'class'        => 'close',
+				'type'            => 'button',
+				'class'           => 'btn-close',
 				'data-bs-dismiss' => 'modal',
-				'aria-label'   => wfMessage( 'bootstrap-components-close-element' )->inContentLanguage()->text(),
-			],
-			Html::rawElement(
-				'span',
-				[ 'aria-hidden' => 'true' ],
-				'&times;'
-			)
+				'aria-label'      => wfMessage( 'bootstrap-components-close-element' )->inContentLanguage()->text(),
+			]
 		);
 		return Html::rawElement(
 				'div',

--- a/src/ModalBuilder.php
+++ b/src/ModalBuilder.php
@@ -103,8 +103,8 @@ class ModalBuilder {
 			'span',
 			[
 				'class'       => 'modal-trigger',
-				'data-toggle' => 'modal',
-				'data-target' => '#' . $id,
+				'data-bs-toggle' => 'modal',
+				'data-bs-target' => '#' . $id,
 			],
 			$element
 		);
@@ -139,7 +139,7 @@ class ModalBuilder {
 	 * Parses the modal.
 	 *
 	 * Emits the trigger followed by the modal container inline. The container is
-	 * `position: fixed` and is addressed via `data-target="#id"`, so its DOM
+	 * `position: fixed` and is addressed via `data-bs-target="#id"`, so its DOM
 	 * placement is not significant.
 	 *
 	 * @return string
@@ -306,8 +306,8 @@ class ModalBuilder {
 	 */
 	protected function buildTrigger() {
 		$trigger = $this->getTrigger();
-		if ( preg_match( '/data-toggle[^"]+"modal/', $trigger )
-			&& preg_match( '/data-target[^"]+"#' . $this->getId() . '"/', $trigger )
+		if ( preg_match( '/data-bs-toggle[^"]+"modal/', $trigger )
+			&& preg_match( '/data-bs-target[^"]+"#' . $this->getId() . '"/', $trigger )
 			&& preg_match( '/class[^"]+"[^"]*modal-trigger' . '/', $trigger )
 		) {
 			return $trigger;
@@ -449,7 +449,7 @@ class ModalBuilder {
 					[
 						'type'         => 'button',
 						'class'        => 'btn btn-default',
-						'data-dismiss' => 'modal',
+						'data-bs-dismiss' => 'modal',
 						'aria-label'   => $close,
 					],
 					$close
@@ -479,7 +479,7 @@ class ModalBuilder {
 			[
 				'type'         => 'button',
 				'class'        => 'close',
-				'data-dismiss' => 'modal',
+				'data-bs-dismiss' => 'modal',
 				'aria-label'   => wfMessage( 'bootstrap-components-close-element' )->inContentLanguage()->text(),
 			],
 			Html::rawElement(

--- a/tests/phpunit/Unit/CarouselGalleryTest.php
+++ b/tests/phpunit/Unit/CarouselGalleryTest.php
@@ -82,17 +82,17 @@ class CarouselGalleryTest extends TestCase {
 					'fade'  => '',
 				],
 				[
-					0 => '<div class="carousel slide carousel-fade firefly" style="float:space" id="youcanttakethesky" data-ride="carousel">' . PHP_EOL
-						. '<ol class="carousel-indicators">' . PHP_EOL
-						. "\t". '<li data-target="#youcanttakethesky" data-slide-to="0" class="active"></li>' . PHP_EOL
-						. "\t". '<li data-target="#youcanttakethesky" data-slide-to="1"></li>' . PHP_EOL
-						. "\t". '<li data-target="#youcanttakethesky" data-slide-to="2"></li>' . PHP_EOL
-						. '</ol>' . PHP_EOL
+					0 => '<div class="carousel slide carousel-fade firefly" style="float:space" id="youcanttakethesky" data-bs-ride="carousel">' . PHP_EOL
+						. '<div class="carousel-indicators">' . PHP_EOL
+						. "\t". '<button type="button" data-bs-target="#youcanttakethesky" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>' . PHP_EOL
+						. "\t". '<button type="button" data-bs-target="#youcanttakethesky" data-bs-slide-to="1" aria-label="Slide 2"></button>' . PHP_EOL
+						. "\t". '<button type="button" data-bs-target="#youcanttakethesky" data-bs-slide-to="2" aria-label="Slide 3"></button>' . PHP_EOL
+						. '</div>' . PHP_EOL
 						. '<div class="carousel-inner">' . PHP_EOL
 						. "\t". '<div class="carousel-item active">[[File:Mal.jpg|Malcolm Reynolds|alt=(alt) Malcolm Reynolds|class=img-fluid]]</div>' . PHP_EOL
 						. "\t". '<div class="carousel-item">[[File:Wash.jpg|Hoban Washburne|link=/List_of_best_Pilots_in_the_Verse|class=img-fluid]]</div>' . PHP_EOL
 						. "\t". '<div class="carousel-item">[[File:MirandaSecretFiles.pdf|(c) by Hands of Blue|page=13|float=none|class=img-fluid]]</div>' . PHP_EOL
-						. '</div><a class="carousel-control-prev" href="#youcanttakethesky" role="button" data-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#youcanttakethesky" role="button" data-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
+						. '</div><a class="carousel-control-prev" href="#youcanttakethesky" role="button" data-bs-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#youcanttakethesky" role="button" data-bs-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
 					'isHTML' => true,
 					'noparse' => true,
 				],
@@ -104,15 +104,15 @@ class CarouselGalleryTest extends TestCase {
 				],
 				[],
 				[
-					0 => '<div class="carousel slide" id="bsc_carousel_0" data-ride="carousel">' . PHP_EOL
-						. '<ol class="carousel-indicators">' . PHP_EOL
-						. "\t". '<li data-target="#bsc_carousel_0" data-slide-to="0" class="active"></li>' . PHP_EOL
-						. "\t". '<li data-target="#bsc_carousel_0" data-slide-to="1"></li>' . PHP_EOL
-						. '</ol>' . PHP_EOL
+					0 => '<div class="carousel slide" id="bsc_carousel_0" data-bs-ride="carousel">' . PHP_EOL
+						. '<div class="carousel-indicators">' . PHP_EOL
+						. "\t". '<button type="button" data-bs-target="#bsc_carousel_0" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>' . PHP_EOL
+						. "\t". '<button type="button" data-bs-target="#bsc_carousel_0" data-bs-slide-to="1" aria-label="Slide 2"></button>' . PHP_EOL
+						. '</div>' . PHP_EOL
 						. '<div class="carousel-inner">' . PHP_EOL
 						. "\t". '<div class="carousel-item active">[[File:Mal.jpg|Malcolm Reynolds|alt=(alt) Malcolm Reynolds|class=img-fluid]]</div>' . PHP_EOL
 						. "\t". '<div class="carousel-item">[[File:Wash.jpg|Hoban Washburne|link=/List_of_best_Pilots_in_the_Verse|class=img-fluid]]</div>' . PHP_EOL
-						. '</div><a class="carousel-control-prev" href="#bsc_carousel_0" role="button" data-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_0" role="button" data-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
+						. '</div><a class="carousel-control-prev" href="#bsc_carousel_0" role="button" data-bs-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_0" role="button" data-bs-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
 					'isHTML' => true,
 					'noparse' => true,
 				],

--- a/tests/phpunit/Unit/Components/AlertTest.php
+++ b/tests/phpunit/Unit/Components/AlertTest.php
@@ -83,17 +83,17 @@ class AlertTest extends ComponentsTestBase {
 			'dismiss_arbitrary'       => [
 				$this->input,
 				[ 'dismissible' => 'bla' ],
-				'<div class="alert alert-primary alert-dismissible" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>',
+				'<div class="alert alert-primary alert-dismissible" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>',
 			],
 			'dismiss'               => [
 				$this->input,
 				[ 'dismissible' => true ],
-				'<div class="alert alert-primary alert-dismissible" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>',
+				'<div class="alert alert-primary alert-dismissible" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>',
 			],
 			'fading'                => [
 				$this->input,
 				[ 'dismissible' => 'fade', 'color' => 'warning' ],
-				'<div class="alert alert-warning alert-dismissible fade show" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>',
+				'<div class="alert alert-warning alert-dismissible fade show" id="bsc_alert_NULL" role="alert">' . $this->input . '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>',
 			],
 			'manual id, no dismiss' => [
 				$this->input,

--- a/tests/phpunit/Unit/Components/BadgeTest.php
+++ b/tests/phpunit/Unit/Components/BadgeTest.php
@@ -69,7 +69,7 @@ class BadgeTest extends ComponentsTestBase {
 			'simple'          => [
 				$this->input,
 				[],
-				'<span class="badge badge-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
+				'<span class="badge text-bg-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
 			],
 			'empty'           => [
 				'',
@@ -79,22 +79,22 @@ class BadgeTest extends ComponentsTestBase {
 			'manual id'       => [
 				$this->input,
 				[ 'id' => 'book' ],
-				'<span class="badge badge-primary" id="book">' . $this->input . '</span>',
+				'<span class="badge text-bg-primary" id="book">' . $this->input . '</span>',
 			],
 			'style and class' => [
 				$this->input,
 				[ 'class' => 'dummy nice', 'style' => 'float:right;background-color:#80266e' ],
-				'<span class="badge badge-primary dummy nice" style="float:right;background-color:#80266e" id="bsc_badge_NULL">' . $this->input . '</span>',
+				'<span class="badge text-bg-primary dummy nice" style="float:right;background-color:#80266e" id="bsc_badge_NULL">' . $this->input . '</span>',
 			],
 			'pill'       => [
 				$this->input,
 				[ 'pill' => 'true' ],
-				'<span class="badge badge-pill badge-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
+				'<span class="badge rounded-pill text-bg-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
 			],
 			'no pill'       => [
 				$this->input,
 				[ 'pill' => 0 ],
-				'<span class="badge badge-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
+				'<span class="badge text-bg-primary" id="bsc_badge_NULL">' . $this->input . '</span>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/ButtonTest.php
+++ b/tests/phpunit/Unit/Components/ButtonTest.php
@@ -80,7 +80,7 @@ class ButtonTest extends ComponentsTestBase {
 		);
 
 		$instance->injectRawAttributes(
-			[ 'data-toggle' => 'foo', 'data-target' => '#bar' ]
+			[ 'data-bs-toggle' => 'foo', 'data-bs-target' => '#bar' ]
 		);
 
 		$generatedOutput = $instance->parseComponent( $parserRequest );
@@ -91,7 +91,7 @@ class ButtonTest extends ComponentsTestBase {
 		$this->assertMatchesRegularExpression(
 			'~^<a class="btn btn-primary btn-md manual" role="button" id="bsc_button_NULL" href=".*/'
 			. str_replace( ' ', '_', $this->input )
-			. '" data-toggle="foo" data-target="#bar">' . $this->input . '</a>$~',
+			. '" data-bs-toggle="foo" data-bs-target="#bar">' . $this->input . '</a>$~',
 			$generatedOutput
 		);
 	}

--- a/tests/phpunit/Unit/Components/CardTest.php
+++ b/tests/phpunit/Unit/Components/CardTest.php
@@ -148,7 +148,7 @@ class CardTest extends ComponentsTestBase {
 					'footer-style'=> 'padding:5px',
 				],
 				'<div class="card border-info dummy nice" style="float:right;background-color:green">'
-				. '<div class="card-header" style="padding:5px" data-toggle="collapse" data-target="#badgers_bowler" aria-controls="badgers_bowler" aria-expanded="true" id="badgers_bowler_header">'
+				. '<div class="card-header" style="padding:5px" data-bs-toggle="collapse" data-bs-target="#badgers_bowler" aria-controls="badgers_bowler" aria-expanded="true" id="badgers_bowler_header">'
 				. '<h4 class="card-title" style="margin-top:0;padding-top:0;">HEADING TEXT</h4></div>[[File:Serenity.png]]'
 				. '<div id="badgers_bowler" class="card-collapse collapse fade show" aria-labelledby="badgers_bowler_header"><div class="card-body text-info" style="padding:5px">'
 				. $this->input . '</div>[[File:Serenity.png|class=card-img-bottom]]<div class="card-footer" style="padding:5px">FOOTER TEXT</div></div></div>',
@@ -179,12 +179,12 @@ class CardTest extends ComponentsTestBase {
 			'simple'            => [
 				$this->input,
 				[],
-				'<div class="card"><div class="card-header" data-toggle="collapse" data-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">bsc_card_NULL</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body">' . $this->input . '</div></div></div>',
+				'<div class="card"><div class="card-header" data-bs-toggle="collapse" data-bs-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">bsc_card_NULL</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-bs-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body">' . $this->input . '</div></div></div>',
 			],
 			'text missing'      => [
 				'',
 				[ 'header' => 'watch this', 'footer' => 'watch what?', 'collapsible' => 'false', ],
-				'<div class="card"><div class="card-header" data-toggle="collapse" data-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">watch this</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body"></div><div class="card-footer">watch what?</div></div></div>',
+				'<div class="card"><div class="card-header" data-bs-toggle="collapse" data-bs-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">watch this</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-bs-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body"></div><div class="card-footer">watch what?</div></div></div>',
 			],
 			'all attributes'    => [
 				$this->input,
@@ -198,12 +198,12 @@ class CardTest extends ComponentsTestBase {
 					'heading'     => 'HEADING TEXT',
 					'footer'      => 'FOOTER TEXT',
 				],
-				'<div class="card border-info dummy nice" style="float:right;background-color:green"><div class="card-header" data-toggle="collapse" data-target="#badgers_bowler" aria-controls="badgers_bowler" aria-expanded="true" id="badgers_bowler_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">HEADING TEXT</h4></div><div id="badgers_bowler" class="card-collapse collapse fade show" data-parent="#accordion0" aria-labelledby="badgers_bowler_header"><div class="card-body text-info">' . $this->input . '</div><div class="card-footer">FOOTER TEXT</div></div></div>',
+				'<div class="card border-info dummy nice" style="float:right;background-color:green"><div class="card-header" data-bs-toggle="collapse" data-bs-target="#badgers_bowler" aria-controls="badgers_bowler" aria-expanded="true" id="badgers_bowler_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">HEADING TEXT</h4></div><div id="badgers_bowler" class="card-collapse collapse fade show" data-bs-parent="#accordion0" aria-labelledby="badgers_bowler_header"><div class="card-body text-info">' . $this->input . '</div><div class="card-footer">FOOTER TEXT</div></div></div>',
 			],
 			'collapsible false' => [
 				$this->input,
 				[ 'collapsible' => 'false', ],
-				'<div class="card"><div class="card-header" data-toggle="collapse" data-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">bsc_card_NULL</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body">' . $this->input . '</div></div></div>',
+				'<div class="card"><div class="card-header" data-bs-toggle="collapse" data-bs-target="#bsc_card_NULL" aria-controls="bsc_card_NULL" aria-expanded="false" id="bsc_card_NULL_header"><h4 class="card-title" style="margin-top:0;padding-top:0;">bsc_card_NULL</h4></div><div id="bsc_card_NULL" class="card-collapse collapse fade" data-bs-parent="#accordion0" aria-labelledby="bsc_card_NULL_header"><div class="card-body">' . $this->input . '</div></div></div>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/CarouselTest.php
+++ b/tests/phpunit/Unit/Components/CarouselTest.php
@@ -79,17 +79,17 @@ class CarouselTest extends ComponentsTestBase {
 			'simple'                     => [
 				'[[File:Mal.jpg|Malcolm Reynolds_0]]',
 				[ '[[File:Mal.jpg|Malcolm Reynolds]]' => true, '[[File:Wash.jpg|link' => '|Hoban Washburne]]' ],
-				'<div class="carousel slide" id="bsc_carousel_NULL" data-ride="carousel">
-<ol class="carousel-indicators">
-	<li data-target="#bsc_carousel_NULL" data-slide-to="0" class="active"></li>
-	<li data-target="#bsc_carousel_NULL" data-slide-to="1"></li>
-	<li data-target="#bsc_carousel_NULL" data-slide-to="2"></li>
-</ol>
+				'<div class="carousel slide" id="bsc_carousel_NULL" data-bs-ride="carousel">
+<div class="carousel-indicators">
+	<button type="button" data-bs-target="#bsc_carousel_NULL" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+	<button type="button" data-bs-target="#bsc_carousel_NULL" data-bs-slide-to="1" aria-label="Slide 2"></button>
+	<button type="button" data-bs-target="#bsc_carousel_NULL" data-bs-slide-to="2" aria-label="Slide 3"></button>
+</div>
 <div class="carousel-inner">
 	<div class="carousel-item active">[[File:Mal.jpg|Malcolm Reynolds_0]]</div>
 	<div class="carousel-item">[[File:Mal.jpg|Malcolm Reynolds]]</div>
 	<div class="carousel-item">[[File:Wash.jpg|link=|Hoban Washburne]]</div>
-</div><a class="carousel-control-prev" href="#bsc_carousel_NULL" role="button" data-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_NULL" role="button" data-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
+</div><a class="carousel-control-prev" href="#bsc_carousel_NULL" role="button" data-bs-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_NULL" role="button" data-bs-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
 			],
 			'images missing'             => [
 				$this->input,
@@ -105,15 +105,15 @@ class CarouselTest extends ComponentsTestBase {
 					'fade'                              => true,
 					'style'                             => 'float:none;background-color:black',
 				],
-				'<div class="carousel slide carousel-fade crew" style="float:none;background-color:black" id="bsc_carousel_NULL" data-ride="carousel">
-<ol class="carousel-indicators">
-	<li data-target="#bsc_carousel_NULL" data-slide-to="0" class="active"></li>
-	<li data-target="#bsc_carousel_NULL" data-slide-to="1"></li>
-</ol>
+				'<div class="carousel slide carousel-fade crew" style="float:none;background-color:black" id="bsc_carousel_NULL" data-bs-ride="carousel">
+<div class="carousel-indicators">
+	<button type="button" data-bs-target="#bsc_carousel_NULL" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+	<button type="button" data-bs-target="#bsc_carousel_NULL" data-bs-slide-to="1" aria-label="Slide 2"></button>
+</div>
 <div class="carousel-inner">
 	<div class="carousel-item active">[[File:Mal.jpg|Malcolm Reynolds]]</div>
 	<div class="carousel-item">[[File:Wash.jpg|link=|Hoban Washburne]]</div>
-</div><a class="carousel-control-prev" href="#bsc_carousel_NULL" role="button" data-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_NULL" role="button" data-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
+</div><a class="carousel-control-prev" href="#bsc_carousel_NULL" role="button" data-bs-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span></a><a class="carousel-control-next" href="#bsc_carousel_NULL" role="button" data-bs-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span></a></div>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/CollapseTest.php
+++ b/tests/phpunit/Unit/Components/CollapseTest.php
@@ -69,27 +69,27 @@ class CollapseTest extends ComponentsTestBase {
 			'simple'          => [
 				$this->input,
 				[],
-				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
+				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-bs-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
 			],
 			'color_unknown'   => [
 				$this->input,
 				[ 'color' => 'unknown' ],
-				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
+				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-bs-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
 			],
 			'button text'     => [
 				$this->input,
 				[ 'text' => 'BUTTON' ],
-				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-toggle="collapse">BUTTON</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
+				'<a class="btn btn-primary" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-bs-toggle="collapse">BUTTON</a><div class="collapse" id="bsc_collapse_NULL">' . $this->input . '</div>',
 			],
 			'manual id'       => [
 				$this->input,
 				[ 'color' => 'success', 'id' => 'alliance' ],
-				'<a class="btn btn-success" role="button" id="bsc_button_NULL" href="#alliance" data-toggle="collapse">#alliance</a><div class="collapse" id="alliance">' . $this->input . '</div>',
+				'<a class="btn btn-success" role="button" id="bsc_button_NULL" href="#alliance" data-bs-toggle="collapse">#alliance</a><div class="collapse" id="alliance">' . $this->input . '</div>',
 			],
 			'style and class' => [
 				$this->input,
 				[ 'class' => 'dummy nice', 'style' => 'float:right;background-color:green' ],
-				'<a class="btn btn-primary dummy nice" style="float:right;background-color:green" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse dummy nice" style="float:right;background-color:green" id="bsc_collapse_NULL">' . $this->input . '</div>',
+				'<a class="btn btn-primary dummy nice" style="float:right;background-color:green" role="button" id="bsc_button_NULL" href="#bsc_collapse_NULL" data-bs-toggle="collapse">#bsc_collapse_NULL</a><div class="collapse dummy nice" style="float:right;background-color:green" id="bsc_collapse_NULL">' . $this->input . '</div>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/JumbotronTest.php
+++ b/tests/phpunit/Unit/Components/JumbotronTest.php
@@ -69,17 +69,17 @@ class JumbotronTest extends ComponentsTestBase {
 			'simple'          => [
 				$this->input,
 				[],
-				'<div class="container"><div class="jumbotron" id="bsc_jumbotron_NULL">' . $this->input . '</div></div>',
+				'<div class="container"><div class="p-5 mb-4 bg-body-tertiary rounded-3" id="bsc_jumbotron_NULL">' . $this->input . '</div></div>',
 			],
 			'manual id'       => [
 				$this->input,
 				[ 'id' => 'hms_dortmunder' ],
-				'<div class="container"><div class="jumbotron" id="hms_dortmunder">' . $this->input . '</div></div>',
+				'<div class="container"><div class="p-5 mb-4 bg-body-tertiary rounded-3" id="hms_dortmunder">' . $this->input . '</div></div>',
 			],
 			'style and class' => [
 				$this->input,
 				[ 'class' => 'dummy nice', 'style' => 'float:right;background-color:green' ],
-				'<div class="container"><div class="jumbotron dummy nice" style="float:right;background-color:green" id="bsc_jumbotron_NULL">' . $this->input . '</div></div>',
+				'<div class="container"><div class="p-5 mb-4 bg-body-tertiary rounded-3 dummy nice" style="float:right;background-color:green" id="bsc_jumbotron_NULL">' . $this->input . '</div></div>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/ModalTest.php
+++ b/tests/phpunit/Unit/Components/ModalTest.php
@@ -79,9 +79,9 @@ class ModalTest extends ComponentsTestBase {
 			'simple'              => [
 				$this->input,
 				[ 'text' => 'BUTTON' ],
-				'<button type="button" class="modal-trigger btn btn-default" data-toggle="modal" data-target="#bsc_modal_NULL">BUTTON</button>',
-				'<div class="modal fade" role="dialog" id="bsc_modal_NULL" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'<button type="button" class="modal-trigger btn btn-default" data-bs-toggle="modal" data-bs-target="#bsc_modal_NULL">BUTTON</button>',
+				'<div class="modal fade" role="dialog" id="bsc_modal_NULL" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'text missing'        => [
 				$this->input,
@@ -95,9 +95,9 @@ class ModalTest extends ComponentsTestBase {
 					'text' => 'before<a href="/File:Serenity.png" class="image"><img alt="Serenity" src="/images/a/aa/Serenity.png" width="160" height="42"></a>after',
 					'size' => 'none',
 				],
-				'<span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_NULL">before<img alt="Serenity" src="/images/a/aa/Serenity.png" width="160" height="42">after</span>',
-				'<div class="modal fade" role="dialog" id="bsc_modal_NULL" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_NULL">before<img alt="Serenity" src="/images/a/aa/Serenity.png" width="160" height="42">after</span>',
+				'<div class="modal fade" role="dialog" id="bsc_modal_NULL" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'all attributes'      => [
 				$this->input,
@@ -106,9 +106,9 @@ class ModalTest extends ComponentsTestBase {
 					'id'      => 'firefly0', 'size' => 'lg', 'class' => 'shiny', 'style' => 'float:right;background-color:black',
 					'heading' => 'You can\'t take the sky from me!',
 				],
-				'<span class="modal-trigger" data-toggle="modal" data-target="#firefly0"><img alt="Serenity" src="/images/a/aa/Serenity.png" width="160" height="42"></span>',
-				'<div class="modal fade shiny" style="float:right;background-color:black" role="dialog" id="firefly0" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><span class="modal-title">You can\'t take the sky from me!</span><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#firefly0"><img alt="Serenity" src="/images/a/aa/Serenity.png" width="160" height="42"></span>',
+				'<div class="modal fade shiny" style="float:right;background-color:black" role="dialog" id="firefly0" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><span class="modal-title">You can\'t take the sky from me!</span><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body">' . $this->input . '</div><div class="modal-footer"><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/PopoverTest.php
+++ b/tests/phpunit/Unit/Components/PopoverTest.php
@@ -69,7 +69,7 @@ class PopoverTest extends ComponentsTestBase {
 			'simple'          => [
 				$this->input,
 				[ 'heading' => 'heading', 'text' => 'BUTTON' ],
-				'<button class="btn btn-info" id="bsc_popover_NULL" data-toggle="popover" title="heading" data-content="' . $this->input . '" type="submit">BUTTON</button>',
+				'<button class="btn btn-info" id="bsc_popover_NULL" data-bs-toggle="popover" title="heading" data-bs-content="' . $this->input . '" type="submit">BUTTON</button>',
 			],
 			'heading empty' => [
 				$this->input,
@@ -87,7 +87,7 @@ class PopoverTest extends ComponentsTestBase {
 					'heading'   => 'heading', 'text' => 'BUTTON', 'class' => 'dummy nice', 'style' => 'float:right;background-color:green',
 					'placement' => 'right', 'trigger' => 'hover', 'id' => 'cudgel', 'size' => 'sm'
 				],
-				'<button class="btn btn-info btn-sm dummy nice" style="float:right;background-color:green" id="cudgel" data-toggle="popover" title="heading" data-content="' . $this->input . '" data-placement="right" data-trigger="hover" type="submit">BUTTON</button>',
+				'<button class="btn btn-info btn-sm dummy nice" style="float:right;background-color:green" id="cudgel" data-bs-toggle="popover" title="heading" data-bs-content="' . $this->input . '" data-bs-placement="right" data-bs-trigger="hover" type="submit">BUTTON</button>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/Components/TooltipTest.php
+++ b/tests/phpunit/Unit/Components/TooltipTest.php
@@ -74,7 +74,7 @@ class TooltipTest extends ComponentsTestBase {
 			'simple'              => [
 				$this->input,
 				[ 'text' => 'simple' ],
-				'<span class="bootstrap-tooltip" id="bsc_tooltip_NULL" data-toggle="tooltip" title="simple">' . $this->input . '</span>',
+				'<span class="bootstrap-tooltip" id="bsc_tooltip_NULL" data-bs-toggle="tooltip" title="simple">' . $this->input . '</span>',
 			],
 			'empty'               => [
 				'',
@@ -89,7 +89,7 @@ class TooltipTest extends ComponentsTestBase {
 			'id, style and class' => [
 				$this->input,
 				[ 'text' => 'simple', 'class' => 'dummy nice', 'style' => 'float:right;background-color:#80266e', 'id' => 'vera' ],
-				'<span class="bootstrap-tooltip dummy nice" style="float:right;background-color:#80266e" id="vera" data-toggle="tooltip" title="simple">' . $this->input . '</span>',
+				'<span class="bootstrap-tooltip dummy nice" style="float:right;background-color:#80266e" id="vera" data-bs-toggle="tooltip" title="simple">' . $this->input . '</span>',
 			],
 		];
 	}

--- a/tests/phpunit/Unit/ImageModalTest.php
+++ b/tests/phpunit/Unit/ImageModalTest.php
@@ -295,9 +295,9 @@ class ImageModalTest extends TestCase {
 			'no params' => [
 				[],
 				[],
-				'~<span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'frame params w/o thumbnail' => [
 				[
@@ -309,9 +309,9 @@ class ImageModalTest extends TestCase {
 					'valign'  => 'text-top',
 				],
 				[],
-				'~<div class="floatleft"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><img src=TEST_OUTPUT alt="test_alt" title="test_title" class="test_class"></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT alt="test_alt" title="test_title" class="test_class img-fluid"> <div class="modal-caption">test_caption:not next line, still not next line, .' . PHP_EOL . PHP_EOL . 'next line</div></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="floatleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><img src=TEST_OUTPUT alt="test_alt" title="test_title" class="test_class"></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT alt="test_alt" title="test_title" class="test_class img-fluid"> <div class="modal-caption">test_caption:not next line, still not next line, .' . PHP_EOL . PHP_EOL . 'next line</div></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'manual width, frameless' => [
 				[
@@ -322,9 +322,9 @@ class ImageModalTest extends TestCase {
 					'width' => 200,
 					'page'  => 7,
 				],
-				'~<div class="floatleft"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png?page=7">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="floatleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png?page=7">Visit Source</a><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'thumbnail, manual width' => [
 				[
@@ -335,9 +335,9 @@ class ImageModalTest extends TestCase {
 					'width' => 200,
 					'page'  => 7,
 				],
-				'~<div class="thumb tmiddle"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:642px;"><img src=TEST_OUTPUT class="thumbimage">  <div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge"></a></div></div></div></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div><div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div>'
-				. '<div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png?page=7">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="thumb tmiddle"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><div class="thumbinner" style="width:642px;"><img src=TEST_OUTPUT class="thumbimage">  <div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge"></a></div></div></div></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div><div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div>'
+				. '<div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png?page=7">Visit Source</a><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'manual thumbnail, NOT centered' => [
 				[
@@ -346,9 +346,9 @@ class ImageModalTest extends TestCase {
 					'framed'      => false,
 				],
 				[],
-				'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;"><span><img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?></span>  <div class="thumbcaption"></div></div></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div><div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div>'
-				. '<div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="thumb tnone"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;"><span><img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?></span>  <div class="thumbcaption"></div></div></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div><div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div>'
+				. '<div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'framed' => [
 				[
@@ -356,9 +356,9 @@ class ImageModalTest extends TestCase {
 					'framed' => false,
 				],
 				[],
-				'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:642px;"><img src=TEST_OUTPUT class="thumbimage">  <div class="thumbcaption"></div></div></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="thumb tnone"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><div class="thumbinner" style="width:642px;"><img src=TEST_OUTPUT class="thumbimage">  <div class="thumbcaption"></div></div></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'centered' => [
 				[
@@ -367,9 +367,9 @@ class ImageModalTest extends TestCase {
 				[
 					'width' => 200,
 				],
-				'~<div class="center"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="center"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><img src=TEST_OUTPUT ></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'manual thumbnail, upright' => [
 				[
@@ -378,9 +378,9 @@ class ImageModalTest extends TestCase {
 					'manualthumb' => 'Shuttle.png',
 				],
 				[],
-				'~<div class="thumb tleft"><span class="modal-trigger" data-toggle="modal" data-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;"><span><img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?></span>  <div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge"></a></div></div></div></span></div>~',
-				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'
-				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'~<div class="thumb tleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#bsc_modal_test"><div class="thumbinner" style="width:96px;"><span><img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?></span>  <div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge"></a></div></div></div></span></div>~',
+				'<div class="modal fade" role="dialog" id="bsc_modal_test" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>'
+				. '<div class="modal-body"><img src=TEST_OUTPUT class="img-fluid"></div><div class="modal-footer"><a class="btn btn-primary" role="button" href="/File:Serenity.png">Visit Source</a><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 		];
 	}

--- a/tests/phpunit/Unit/ImageModalTriggerTest.php
+++ b/tests/phpunit/Unit/ImageModalTriggerTest.php
@@ -164,7 +164,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page' => false,
 				],
 				[
-					'~<span class="modal-trigger" data-toggle="modal" data-target="#id"><img src="thumbnail::toHtml\(\)/return/value\.png" ></span>~',
+					'~<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id"><img src="thumbnail::toHtml\(\)/return/value\.png" ></span>~',
 				]
 			],
 			'frame params w/o thumbnail'     => [
@@ -184,7 +184,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page' => false,
 				],
 				[
-					'~<div class="floatleft"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
+					'~<div class="floatleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id">~',
 					'~<img src="thumbnail::toHtml\(\)/return/value\.png" alt="test_alt" title="test_title" class="test_class">~',
 				]
 			],
@@ -206,7 +206,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page'  => 7,
 				],
 				[
-					'~<div class="floatleft"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
+					'~<div class="floatleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id">~',
 					'~<img src="thumbnail::toHtml\(\)/return/value\.png" >~',
 				]
 			],
@@ -228,7 +228,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page'  => 7,
 				],
 				[
-					'~<div class="thumb tmiddle"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
+					'~<div class="thumb tmiddle"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id">~',
 					'~<div class="thumbinner" style="width:642px;"><img src="thumbnail::toHtml\(\)/return/value\.png" class="thumbimage">~',
 					'~<div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge">~',
 				]
@@ -252,7 +252,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page' => false,
 				],
 				[
-					'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
+					'~<div class="thumb tnone"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id">~',
 					'~<div class="thumbinner" style="width:96px;">~',
 					'~<img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?>~',
 				]
@@ -274,7 +274,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page' => false,
 				],
 				[
-					'~<div class="thumb tnone"><span class="modal-trigger" data-toggle="modal" data-target="#id">~',
+					'~<div class="thumb tnone"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id">~',
 					'~<div class="thumbinner" style="width:642px;"><img src="thumbnail::toHtml\(\)/return/value\.png" class="thumbimage">~',
 				]
 			],
@@ -296,7 +296,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page'  => false,
 				],
 				[
-					'~<div class="center"><span class="modal-trigger" data-toggle="modal" data-target="#id"><img src="thumbnail::toHtml\(\)/return/value\.png" >~',
+					'~<div class="center"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id"><img src="thumbnail::toHtml\(\)/return/value\.png" >~',
 				]
 			],
 			'manual thumbnail, upright'      => [
@@ -318,7 +318,7 @@ class ImageModalTriggerTest extends TestCase {
 					'page' => false,
 				],
 				[
-					'~<div class="thumb tleft"><span class="modal-trigger" data-toggle="modal" data-target="#id"><div class="thumbinner" style="width:96px;">~',
+					'~<div class="thumb tleft"><span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id"><div class="thumbinner" style="width:96px;">~',
 					'~<img( alt="")? src="' . $scriptPath . '/images/a/aa/Shuttle.png" decoding="async" width="94" height="240" class="thumbimage"( /)?>~',
 					'~<div class="thumbcaption"><div class="magnify"><a class="internal" title="Enlarge">~',
 				]

--- a/tests/phpunit/Unit/ModalBuilderTest.php
+++ b/tests/phpunit/Unit/ModalBuilderTest.php
@@ -79,9 +79,9 @@ class ModalBuilderTest extends TestCase {
 				'outerClass0',
 				'outerStyle0',
 				'innerClass0',
-				'<span class="modal-trigger" data-toggle="modal" data-target="#id0">trigger0</span>',
+				'<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id0">trigger0</span>',
 				'<div class="modal fade outerClass0" style="outerStyle0" role="dialog" id="id0" aria-hidden="true"><div class="modal-dialog innerClass0"><div class="modal-content"><div class="modal-header"><span class="modal-title">header0</span>'
-				. '<button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button></div><div class="modal-body">content0</div><div class="modal-footer">footer0<button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				. '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div><div class="modal-body">content0</div><div class="modal-footer">footer0<button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 			'scarce' => [
 				'id1',
@@ -92,9 +92,9 @@ class ModalBuilderTest extends TestCase {
 				'',
 				'',
 				'',
-				'<span class="modal-trigger" data-toggle="modal" data-target="#id1">trigger1</span>',
-				'<div class="modal fade" role="dialog" id="id1" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close">'
-				. '<span aria-hidden="true">&times;</span></button></div><div class="modal-body">content1</div><div class="modal-footer"><button type="button" class="btn btn-default" data-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
+				'<span class="modal-trigger" data-bs-toggle="modal" data-bs-target="#id1">trigger1</span>',
+				'<div class="modal fade" role="dialog" id="id1" aria-hidden="true"><div class="modal-dialog"><div class="modal-content"><div class="modal-header"><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">'
+				. '</button></div><div class="modal-body">content1</div><div class="modal-footer"><button type="button" class="btn btn-default" data-bs-dismiss="modal" aria-label="Close">Close</button></div></div></div></div>' . "\n",
 			],
 		];
 	}

--- a/tests/phpunit/Unit/mw.bootstrap.parse.tests.lua
+++ b/tests/phpunit/Unit/mw.bootstrap.parse.tests.lua
@@ -55,7 +55,7 @@ local tests = {
 			return removeId ( mw.bootstrap.parse( component, input, args ) )
 		end,
 		args = { 'alert', 'Alert content', { color = 'success', dismissible = 'fade', noStrip = true } },
-		expect = { '<div class="alert alert-success alert-dismissible fade show" role="alert">Alert content<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>' }
+		expect = { '<div class="alert alert-success alert-dismissible fade show" role="alert">Alert content<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>' }
 	},
 }
 


### PR DESCRIPTION
### Scope discipline

This PR is the BS4→BS5 framework lift only.

**Not in scope**:

- Modal stacking architecture / teleport — tracked at #91.
- Per-skin module loading audit, `popover.vector-fix` BS3 selector, `.alert-default` cleanup, `.carousel-inner > .item` cleanup — tracked at #90.
- Further PHP modernizations beyond #83.

### Verification

Tested with MW 1.43.8, `mediawiki/bootstrap ^6.0` (Bootstrap framework 5.3.x), Chameleon at master HEAD ([`128fe31`](https://github.com/ProfessionalWiki/chameleon/commit/128fe31)) and Medik at master HEAD ([`f7ca0ac`](https://github.com/wikiskripta/Medik/commit/f7ca0ac)). Two candidate wikis stood up side-by-side: Chameleon-default and Medik-default. Skin:Chameleon and Skin:Medik are only installed on their respective stack (`useskin=<other-BS-skin>` falls back to the wiki's default), so each was exercised on the stack that actually loads it. MW-core skins (`vector-2022`, `vector`, `monobook`, `timeless`) were exercised via `?useskin=`.

A single wikitext test page, `BCTestMatrix`, exercises every BC component across every documented attribute / colour / size / placement value (modals in five colours and three sizes, popovers in four placements and three trigger modes, eight alert colours plus dismissible variants, three-pane accordion, three-image carousel, the full button / badge / card / jumbotron matrix). Each interactive component was driven via Playwright with real user-input events (real `mouseenter` for tooltips, click toggles for collapse / modal / popover), and assertions cover both the visible state (`.modal.show`, `.popover.show` with BS5-shaped `.popover-header` / `.popover-body`, `.btn-close`-style dismissals) and the framework-level z-indices (modal 1055 / backdrop 1050 / popover 1070).

#### Per-skin matrix of JS-driven components

Badge, Button, and Jumbotron have no JS and aren't listed; their rendering is covered by the screenshots below.

| Skin | Modal | Popover | Tooltip | Alert | Card | Accordion | Carousel |
|---|---|---|---|---|---|---|---|
| chameleon | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| medik | ✓ | ✓ | ✓ | ✓ | ⚠ collapsible | ✓ | ✓ |
| vector-2022 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| vector (legacy) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| monobook | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| timeless | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

The ⚠ on the Medik / Card cell is the collapsible variant only; static cards render correctly. See [Known issues](#known-issues) below.

#### Rendered output per skin

The same `BCTestMatrix` wikitext rendered under each skin (full-page screenshots):

| chameleon | medik | vector-2022 | vector (legacy) | monobook | timeless |
|---|---|---|---|---|---|
| <img width="1280" height="6209" alt="BCTestMatrix-chameleon" src="https://github.com/user-attachments/assets/9df3ffbb-6c16-4f54-849f-a8a9997ed065" /> | <img width="1280" height="5308" alt="BCTestMatrix-medik" src="https://github.com/user-attachments/assets/f7edbd71-3c80-4221-b13b-246596935d57" /> | <img width="1280" height="5138" alt="BCTestMatrix-vector-2022" src="https://github.com/user-attachments/assets/f59f29a4-ca47-4470-9fe0-a2616f9fbb92" /> | <img width="1307" height="5161" alt="BCTestMatrix-vector" src="https://github.com/user-attachments/assets/c9079d3a-2d30-4c5e-a69d-b21674ec2071" /> | <img width="1280" height="5256" alt="BCTestMatrix-monobook" src="https://github.com/user-attachments/assets/98bf8321-93b3-4ba9-a7b4-e2269635e4d0" /> | <img width="1280" height="6085" alt="BCTestMatrix-timeless" src="https://github.com/user-attachments/assets/997304ec-4787-4a58-8f87-df98106a15de" /> |

Test page wikitext: [BCTestMatrix.txt](https://github.com/user-attachments/files/28399009/BCTestMatrix.txt)

Side-by-side baseline comparison against the BS4 5.x release showed only expected BS4→BS5 stylistic evolution: BS5's `.btn-close` SVG icon vs BS4's `×` character; softer pastel BS5 alert palette; jumbotron utility-class composition (`p-5 mb-4 bg-body-tertiary rounded-3`) replacing the dropped `.jumbotron`. No functional or layout regressions outside the Skin:Medik card-collapsible defect noted below.

### Known issues

**Skin:Medik: BS5 collapsible components don't re-toggle.** On Skin:Medik, clicking the same `[data-bs-toggle="collapse"]` trigger a second time doesn't re-hide the panel. Affects standalone collapsible cards and accordion same-pane re-clicks. Caused by BS5 being loaded twice on the page — Skin:Medik bundles its own copy alongside BC's `ext.bootstrap.scripts`, which produces duplicate event-handler registrations on the same trigger. Fix tracked at [#70](https://github.com/oetterer/BootstrapComponents/issues/70).










