### PR TITLE
Declare the Lua test engine for MediaWiki 1.46+

### DIFF
--- a/tests/phpunit/Unit/LuaLibraryTestBase.php
+++ b/tests/phpunit/Unit/LuaLibraryTestBase.php
@@ -22,6 +22,10 @@ abstract class LuaLibraryTestBase extends LuaEngineTestBase
 	 */
 	private $luaLibrary;
 
+	protected function getEngineName(): string {
+		return 'LuaStandalone';
+	}
+
 	/**
 	 * @throws RuntimeException
 	 */


### PR DESCRIPTION
## Why

MediaWiki 1.46 reworked Scribunto's PHPUnit test base. `LuaEngineTestBase` now
requires each subclass to declare its engine via `getEngineName()`; the previous
pattern, where one test class was run against every available engine through a
data provider, is deprecated. Without the method, the `LuaLibrary*` tests error
on 1.46+ with `... must implement getEngineName()`.

## What

`LuaLibraryTestBase` now declares `getEngineName(): 'LuaStandalone'`. LuaStandalone
is chosen because Scribunto bundles its interpreter, so the tests run in CI with no
extra Lua extension to install (a LuaSandbox target would be skipped wherever
`php-luasandbox` is absent).

Older MediaWiki versions (REL1_43 to REL1_45) don't call `getEngineName()` and keep
using the data-provider pattern, so the method is inert there and the change stays
compatible across the whole supported range.

## Note

This is a focused Scribunto-1.46 compatibility fix. The `1.46`/`master` matrix rows
remain `experimental` and continue to fail on separate, unrelated compatibility
issues that are being addressed independently; this change does not by itself turn
those rows green.
