### PR TITLE
Force the integration-test bootstrap for MediaWiki 1.46+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,8 @@ jobs:
               wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
             fi
             composer phpunit:config
-            vendor/bin/phpunit -c phpunit.xml extensions/BootstrapComponents/tests/phpunit/Unit
+            # Temporary integration-test workaround; see issue #98.
+            MEDIAWIKI_HAS_INTEGRATION_TESTS=1 vendor/bin/phpunit -c phpunit.xml extensions/BootstrapComponents/tests/phpunit/Unit
           fi
 
       - if: env.TYPE == 'coverage'
@@ -119,7 +120,8 @@ jobs:
               wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
             fi
             composer phpunit:config
-            vendor/bin/phpunit -c phpunit.xml extensions/BootstrapComponents/tests/phpunit/Unit --coverage-clover coverage.clover
+            # Temporary integration-test workaround; see issue #98.
+            MEDIAWIKI_HAS_INTEGRATION_TESTS=1 vendor/bin/phpunit -c phpunit.xml extensions/BootstrapComponents/tests/phpunit/Unit --coverage-clover coverage.clover
           fi
 
       - if: env.TYPE == 'coverage'


### PR DESCRIPTION
## What

MediaWiki 1.46 replaced `tests/phpunit/phpunit.php` with `vendor/bin/phpunit`, whose
bootstrap treats a `/unit` test path as unit-only and skips loading MediaWiki settings
and the service container. BootstrapComponents' `tests/phpunit/Unit/` tests are not
strictly unit tests (they use MediaWiki services), so under the new runner they error
with `Premature access to service container`.

Forcing the integration-test bootstrap via `MEDIAWIKI_HAS_INTEGRATION_TESTS=1` lets them
run. The pre-1.46 rows are unaffected; the `1.46`/`master` rows stay `experimental`.

## Temporary

This is a workaround. The proper fix, reclassifying the service-using tests as
integration tests so the override is no longer needed, is tracked in #98.
