### PR TITLE
Declare ImageModal's nullable constructor parameter explicitly

### DIFF
--- a/src/ImageModal.php
+++ b/src/ImageModal.php
@@ -68,7 +68,7 @@ class ImageModal implements NestableInterface {
 		private File $file,
 		private NestingController $nestingController,
 		private BootstrapComponentsService $bootstrapComponentService,
-		ParserOutputHelper $parserOutputHelper = null,
+		?ParserOutputHelper $parserOutputHelper = null,
 	) {
 		$this->parserOutputHelper = $parserOutputHelper
 			?? ApplicationFactory::getInstance()->getParserOutputHelper();


### PR DESCRIPTION
## Why

PHP 8.4 deprecates implicitly nullable parameters (`Type $x = null` without the `?`).
`ImageModal::__construct()` declares `ParserOutputHelper $parserOutputHelper = null`, the
only such parameter in `src/`.

The deprecation alone is harmless, but MediaWiki's test runner escalates deprecations to
errors. Because this one fires at class-compile time, it aborts the class declaration and
shows up as `Class "MediaWiki\Extension\BootstrapComponents\ImageModal" not found` on the
PHP 8.4+ CI rows.

## What

Use the explicit `?ParserOutputHelper` form.

## Compatibility

`?ParserOutputHelper $x = null` and `ParserOutputHelper $x = null` are semantically
identical (`ParserOutputHelper|null`), and the explicit form is valid since PHP 7.1. On
PHP 8.1 to 8.3 (REL1_43 to REL1_45) there is no deprecation either way, so this is a
no-op there; it only removes the fatal on PHP 8.4+. Verified on a PHP 8.1 stack: the
ImageModal tests behave identically with and without the change.
