### PR TITLE
Declare the Lua test engine for MediaWiki 1.46+

### DIFF
--- a/tests/phpunit/Unit/LuaLibraryTestBase.php
+++ b/tests/phpunit/Unit/LuaLibraryTestBase.php
@@ -22,6 +22,10 @@ abstract class LuaLibraryTestBase extends LuaEngineTestBase
 	 */
 	private $luaLibrary;
 
+	protected function getEngineName(): string {
+		return 'LuaStandalone';
+	}
+
 	/**
 	 * @throws RuntimeException
 	 */


### PR DESCRIPTION
## Why

Scribunto 1.46 reworked its PHPUnit test base: each `LuaEngineTestBase` subclass must now
declare its engine via `getEngineName()`, and the previous pattern (one class run against
every available engine) is deprecated. Without the method, the `LuaLibrary*` tests error
on 1.46+ with `... must implement getEngineName()`.

## What

`LuaLibraryTestBase` declares `getEngineName(): 'LuaStandalone'`. LuaStandalone is chosen
because Scribunto bundles its interpreter, so the tests run in CI with no extra Lua
extension to install.

## Effect on MediaWiki < 1.46

Pre-1.46 MediaWiki does not call `getEngineName()`; it runs each test against every
configured engine via its own `suite()`/`makeSuite()` machinery. The method is therefore
inert on REL1_43 to REL1_45, which keep running the Lua tests on LuaStandalone exactly as
before (verified on PHP 8.1: identical results with and without the method). This change
only affects 1.46+.
