### PR TITLE
Return a string from the mocked recursiveTagParse

### DIFF
--- a/tests/phpunit/Unit/CarouselGalleryTest.php
+++ b/tests/phpunit/Unit/CarouselGalleryTest.php
@@ -52,7 +52,9 @@ class CarouselGalleryTest extends TestCase {
 			->getMock();
 		$instance->mParser->expects( $this->any() )
 			->method( 'recursiveTagParse' )
-			->will( $this->returnArgument( 0 ) );
+			->will( $this->returnCallback( function ( $text ) {
+				return (string)$text;
+			} ) );
 
 		foreach ( $imageList as $imageData ) {
 			$instance->add( Title::newFromText( $imageData[0] ), $imageData[1], $imageData[2], $imageData[3], $imageData[4] );

--- a/tests/phpunit/Unit/ComponentsTestBase.php
+++ b/tests/phpunit/Unit/ComponentsTestBase.php
@@ -58,10 +58,14 @@ abstract class ComponentsTestBase extends TestCase {
 		$this->parser = $this->createMock( Parser::class );
 		$this->parser->expects( $this->any() )
 			->method( 'recursiveTagParse' )
-			->will( $this->returnArgument( 0 ) );
+			->will( $this->returnCallback( function ( $text ) {
+				return (string)$text;
+			} ) );
 		$this->parser->expects( $this->any() )
 			->method( 'recursiveTagParseFully' )
-			->will( $this->returnArgument( 0 ) );
+			->will( $this->returnCallback( function ( $text ) {
+				return (string)$text;
+			} ) );
 		$this->parserOutputHelper = $this->createMock( ParserOutputHelper::class );
 		$this->parserOutputHelper->expects( $this->any() )
 			->method( 'renderErrorMessage' )


### PR DESCRIPTION
## Why

MediaWiki master declares `Parser::recursiveTagParse()` and `recursiveTagParseFully()`
with a `string` return type (the parameter stays untyped). The component tests mock these
with `returnArgument(0)`, echoing the input verbatim. When a component parses an attribute
value that is a bool or int, the mock returns that non-string and PHPUnit's typed mock
throws:

```
TypeError: Mock_Parser::recursiveTagParse(): Return value must be of type string, true returned
```

### Why an attribute value is a bool

This is not an unrealistic fixture. `ParserRequest` builds its attribute array from what the
parser passes in, and for the parser-function syntax a valueless option is stored as a PHP
`true` (an empty one as `false`) by `ParserRequest::getKeyValuePairFrom()`. So
`[ 'disabled' => true ]` is exactly what `{{#bootstrap_button:text|disabled}}` produces; the
tag-extension syntax (`<bootstrap_button disabled>`) yields a string instead. Both reach
`recursiveTagParse()`.

In production the real `recursiveTagParse()` coerces such a value and returns a string, so it
works. The mock's `returnArgument(0)` did not coerce, which is the only reason the typed
return now fails.

## What

Make the `recursiveTagParse` / `recursiveTagParseFully` mocks return `(string)$text`, so the
mock behaves like the real parser and honours the `string` return contract. The realistic
bool/int inputs are kept and no assertions change (`true` stays truthy as `"1"`, `0` stays
falsy as `"0"`). The `renderErrorMessage` mock is left as-is.

## Verification

Test-only change. On MediaWiki master the component tests that hit the `TypeError` now pass;
the older rows are unaffected, since the cast is a no-op for the string inputs they use.
