### PR TITLE
Add @covers annotations to the service-wiring tests

### DIFF
--- a/tests/phpunit/Unit/ServiceWiringTest.php
+++ b/tests/phpunit/Unit/ServiceWiringTest.php
@@ -22,6 +22,9 @@ use PHPUnit\Framework\TestCase;
 class ServiceWiringTest extends TestCase {
 
 
+	/**
+	 * @covers  \MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService
+	 */
 	public function testCanConstructBootstrapComponentsService()	{
 		$this->assertInstanceOf(
 			BootstrapComponentsService::class,
@@ -29,6 +32,9 @@ class ServiceWiringTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @covers  \MediaWiki\Extension\BootstrapComponents\ComponentLibrary
+	 */
 	public function testCanConstructComponentLibrary()	{
 		$this->assertInstanceOf(
 			ComponentLibrary::class,
@@ -36,6 +42,9 @@ class ServiceWiringTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @covers  \MediaWiki\Extension\BootstrapComponents\NestingController
+	 */
 	public function testCanConstructNestingController()	{
 		$this->assertInstanceOf(
 			NestingController::class,


### PR DESCRIPTION
## Why

MediaWiki's generated PHPUnit configuration sets `forceCoversAnnotation`, so any test without a `@covers` annotation is reported as risky. On the 1.46/master CI rows, three tests in `tests/phpunit/Unit/ServiceWiringTest.php` were flagged risky for this reason:

- `testCanConstructBootstrapComponentsService`
- `testCanConstructComponentLibrary`
- `testCanConstructNestingController`

## What

Each test method now carries a `@covers` annotation naming the class it constructs through the extension's service wiring (`BootstrapComponentsService`, `ComponentLibrary`, `NestingController` respectively), matching the FQCN style already used elsewhere in the unit suite.

This clears only the `@covers` risky warnings for these three tests. The remaining `getOutput` errors on those CI rows are unrelated and will be addressed separately.