### PR TITLE
Return a ParserOutput from the mocked getOutput

### DIFF
--- a/tests/phpunit/Unit/ParserOutputHelperTest.php
+++ b/tests/phpunit/Unit/ParserOutputHelperTest.php
@@ -55,7 +55,7 @@ class ParserOutputHelperTest extends TestCase {
 		$parser = $this->createMock( 'Parser' );
 		$parser->expects( $this->once() )
 			->method( 'getOutput' )
-			->willReturn( false );
+			->willReturn( new ParserOutput( 'ParserOutputMockText' ) );
 
 		$instance = new ParserOutputHelper( $parser );
 
@@ -67,7 +67,7 @@ class ParserOutputHelperTest extends TestCase {
 		$parser = $this->createMock( 'Parser' );
 		$parser->expects( $this->once() )
 			->method( 'getOutput' )
-			->willReturn( false );
+			->willReturn( new ParserOutput( 'ParserOutputMockText' ) );
 
 		$instance = new ParserOutputHelper( $parser );
 


### PR DESCRIPTION
## Why

MediaWiki master declares `Parser::getOutput(): ParserOutput`. `ParserOutputHelperTest::testCanAddErrorTrackingCategory` and `testCanAddTrackingCategory` stub it with `->willReturn( false )`, which PHPUnit's typed mock rejects:

```
IncompatibleReturnValueException: Method getOutput may not return value of type boolean, its declared return type is "MediaWiki\Parser\ParserOutput"
```

The `false` only existed to drive an internal "no ParserOutput" guard in `ParserOutputHelper` that the code comments mark as test-only; the real `getOutput()` always returns a `ParserOutput`.

## What

Return a `ParserOutput` from the two mocks, matching the method's contract (and `setUp()`'s existing `new ParserOutput( 'ParserOutputMockText' )`). The tests' load-bearing idempotency assertions are unchanged; the error-category test now actually reaches `addCategory()` rather than being short-circuited by the test-only guard.

## Verification

Test-only change. On MediaWiki master the two `getOutput` errors clear and `ParserOutputHelperTest` passes; the pre-1.46 rows are unaffected.
