### PR TITLE
Bump the Node-based GitHub Actions off Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             mediawiki
@@ -69,12 +69,12 @@ jobs:
           key: mw_${{ matrix.mw }}-php${{ matrix.php }}
 
       - name: Cache Composer cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: composer-php${{ matrix.php }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: EarlyCopy
 
@@ -83,7 +83,7 @@ jobs:
         working-directory: ~
         run: bash EarlyCopy/.github/workflows/installWiki.sh ${{ matrix.mw }} BootstrapComponents
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: mediawiki/extensions/BootstrapComponents
 


### PR DESCRIPTION
## Why

GitHub Actions is removing the Node.js 20 runtime (JavaScript actions are forced to Node 24 from mid-June 2026, and Node 20 is removed in September 2026). `actions/checkout@v4` and `actions/cache@v4` run on Node 20 and emit the deprecation warning seen in the CI logs.

## What

Bump both to v5, which run on Node 24:
- `actions/checkout@v4` -> `@v5` (x2)
- `actions/cache@v4` -> `@v5` (x2)

`shivammathur/setup-php@v2` is left as-is: v2 is its current rolling major, already runs on Node 24, and was not among the flagged actions.

No workflow behaviour changes; this only moves the actions onto the supported runtime so the logs are warning-free.
