### PR TITLE
CI: get REL1_39 through REL1_43 green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           - mw: 'REL1_43'
             php: 8.3
             type: normal
-            experimental: true
+            experimental: false
           - mw: 'master'
             php: 8.4
             type: normal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,6 @@ jobs:
             php: 8.3
             type: normal
             experimental: false
-          - mw: 'master'
-            php: 8.4
-            type: normal
-            experimental: true
 
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/installWiki.sh
+++ b/.github/workflows/installWiki.sh
@@ -4,10 +4,7 @@ MW_BRANCH=$1
 EXTENSION_NAME=$2
 
 ## install core
-wget https://github.com/wikimedia/mediawiki/archive/${MW_BRANCH}.tar.gz -nv
-
-tar -zxf $MW_BRANCH.tar.gz
-mv mediawiki-$MW_BRANCH mediawiki
+git clone --depth 1 --branch ${MW_BRANCH} https://github.com/wikimedia/mediawiki.git mediawiki
 cd $MW_ROOT
 
 composer install
@@ -35,10 +32,8 @@ git clone --branch ${MW_BRANCH} https://github.com/wikimedia/Vector.git
 
 ## Scribunto
 cd ../extensions
-wget https://github.com/wikimedia/mediawiki-extensions-Scribunto/archive/${MW_BRANCH}.tar.gz
-tar -zxf ${MW_BRANCH}.tar.gz
 [[ -e Scribunto ]] && rm -rf Scribunto
-mv mediawiki-extensions-Scribunto* Scribunto
+git clone --depth 1 --branch ${MW_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Scribunto.git Scribunto
 cd ..
 
 


### PR DESCRIPTION
This branch did more than its original "promote REL1_43" intent: the install script is bitrotted and was silently failing every REL1_39-1.42 row, and the master matrix row was testing across a 3-version gap. This PR addresses all three.

## Promote REL1_43 from experimental to non-experimental

REL1_43 has been passing on 5.x in practice, but the matrix declared it experimental, which masks regressions behind a permissive flag. Flipped to non-experimental so MediaWiki 1.43 LTS is a declared, supported target.

## Fix install-script bitrot affecting REL1_39 through REL1_42

Wikimedia recently converted older MediaWiki release refs (REL1_39 through REL1_42, plus older extension/skin branches) from branches to tags. The original branch refs still exist for now, so the same names resolve as both a branch AND a tag. GitHub's archive endpoint can no longer disambiguate the bare `archive/<name>.tar.gz` URL form in that state, and returns an HTTP 300 Multiple Choices with a 105-byte body:

> the given path has multiple possibilities: #<Git::Ref:...>, #<Git::Ref:...>

`installWiki.sh` then tried to `tar -zxf` 105 bytes of HTML and silently produced no `mediawiki/` directory, and every subsequent step exploded with file-not-found errors. Switching `installWiki.sh` to `git clone --depth 1 --branch <name>` resolves correctly to whichever ref form exists, matches the clone style already used immediately below for Vector and Scribunto, and is robust to whatever Wikimedia does with the refs next.

## Drop the master matrix row

The matrix skips MediaWiki 1.44, 1.45, and 1.46 because the extension fails to load on those versions in the unit-test bootstrap (see below). Testing the master tip across that gap doesn't produce a signal worth acting on: when it passes it's coincidence, when it fails it's the same wall, and `experimental: true` mutes the result either way.

## Out of scope

REL1_44+ fails on a class-resolution wall in MediaWiki's stricter unit-test bootstrap from 1.44 onwards (the bootstrap stops auto-loading the MW autoloader, so the extension's bare-name imports like `use Title;` no longer resolve). Bridging that needs either class_alias shims or namespace-import modernization across the extension, both larger changes than this CI fix.