### PR TITLE
CI: switch the install script to git clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v2
 
       - name: Cache Composer cache
         uses: actions/cache@v5
@@ -101,9 +101,6 @@ jobs:
             php tests/phpunit/phpunit.php -c extensions/BootstrapComponents/ --testsuite bootstrap-components-unit
           else
             # MW 1.46 and later
-            if [ ! -f phpunit.xml.template ]; then
-              wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
-            fi
             composer phpunit:config
             # Temporary integration-test workaround; see issue #98.
             MEDIAWIKI_HAS_INTEGRATION_TESTS=1 vendor/bin/phpunit -c phpunit.xml extensions/BootstrapComponents/tests/phpunit/Unit
@@ -116,9 +113,6 @@ jobs:
             php tests/phpunit/phpunit.php -c extensions/BootstrapComponents/ --testsuite bootstrap-components-unit --coverage-clover coverage.clover
           else
             # MW 1.46 and later
-            if [ ! -f phpunit.xml.template ]; then
-              wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
-            fi
             composer phpunit:config
             # Temporary integration-test workaround; see issue #98.
             MEDIAWIKI_HAS_INTEGRATION_TESTS=1 vendor/bin/phpunit -c phpunit.xml extensions/BootstrapComponents/tests/phpunit/Unit --coverage-clover coverage.clover

--- a/.github/workflows/installWiki.sh
+++ b/.github/workflows/installWiki.sh
@@ -4,10 +4,7 @@ MW_BRANCH=$1
 EXTENSION_NAME=$2
 
 ## install core
-wget https://github.com/wikimedia/mediawiki/archive/${MW_BRANCH}.tar.gz -nv
-
-tar -zxf $MW_BRANCH.tar.gz
-mv mediawiki-$MW_BRANCH mediawiki
+git clone --depth 1 --branch ${MW_BRANCH} https://github.com/wikimedia/mediawiki.git mediawiki
 cd $MW_ROOT
 
 composer install
@@ -35,10 +32,8 @@ git clone --branch ${MW_BRANCH} https://github.com/wikimedia/Vector.git
 
 ## Scribunto
 cd ../extensions
-wget https://github.com/wikimedia/mediawiki-extensions-Scribunto/archive/${MW_BRANCH}.tar.gz
-tar -zxf ${MW_BRANCH}.tar.gz
 [[ -e Scribunto ]] && rm -rf Scribunto
-mv mediawiki-extensions-Scribunto* Scribunto
+git clone --depth 1 --branch ${MW_BRANCH} https://github.com/wikimedia/mediawiki-extensions-Scribunto.git Scribunto
 cd ..
 
 


### PR DESCRIPTION
Preventive + cleanup follow-up to #107, which fixed the same install-script bitrot on the 5.x branch.

## Switch the install script to `git clone`

Wikimedia recently converted older MediaWiki release refs (REL1_39 through REL1_42, plus older extension/skin branches) from branches to tags. The original branch refs still exist for now, so the same names resolve as both a branch AND a tag. GitHub's archive endpoint can no longer disambiguate the bare `archive/<name>.tar.gz` URL form in that state, and returns an HTTP 300 Multiple Choices with a 105-byte body:

> the given path has multiple possibilities: #<Git::Ref:...>, #<Git::Ref:...>

The master matrix only tests REL1_43+ so this is not failing today, but it is a latent hazard. Switching `installWiki.sh` to `git clone --depth 1 --branch <name>` resolves whichever ref form exists, matches the clone style already in use immediately below for Vector and Scribunto, and is robust to whatever Wikimedia does with the refs next.

## Drop the redundant wget for `phpunit.xml.template`

The new-runner code path was fetching `phpunit.xml.template` from `raw.githubusercontent.com` because MediaWiki marks the file `export-ignore` in `.gitattributes`, which excludes it from `git archive` output (and therefore from GitHub's `archive/<ref>.tar.gz` tarball endpoint). `git clone` does not honour `export-ignore` — the file is in the working tree after a normal checkout. With `installWiki.sh` now using `git clone`, the separate wget becomes dead code in both the normal and coverage PHPUnit invocations.

## Bump the cache key

Existing wget-era cache entries (keyed `mw_<mw>-php<php>`) lack `phpunit.xml.template` because they were populated from the archive tarball. Without a key bump, on every cache hit after merge the file would be absent and `composer phpunit:config` would fail. Bump to `-v2` so the next run on each cache key produces a fresh entry from the `git clone` path, with the file included.