### PR TITLE
Make carousel indicator aria-label translatable

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -13,6 +13,8 @@
 
 	"bootstrap-components-image-modal-source-button" : "Visit Source",
 
+	"bootstrap-components-carousel-slide-label" : "Slide $1",
+
 	"bootstrap-components-lua-error-no-component": "No component name provided for mw.bootstrap.parse.",
 	"bootstrap-components-lua-error-invalid-component": "Invalid component name passed to mw.bootstrap.parse: $1.",
 

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -10,6 +10,7 @@
 	"bootstrap-components-tracking-category": "Tracking category for pages with calls to at least one bootstrap tag.\n\n{{Notranslate}}",
 	"bootstrap-components-close-element": "Text for the close button of various components.\n\n{{Identical|Close}}",
 	"bootstrap-components-image-modal-source-button": "Text on the button linking to the image source page.",
+	"bootstrap-components-carousel-slide-label": "Text for the accessibility label of a carousel indicator button.\n\nParameters:\n* $1 - slide number",
 	"bootstrap-components-lua-error-no-component": "Error message that indicates, that there was no component name provided to the lua parse function.",
 	"bootstrap-components-lua-error-invalid-component": "Error message that indicates, that there was an invalid component name provided to the lua parse function.\n\nParameters:\n* $1 - invalid component provided",
 	"bootstrap-components-badge-content-missing": "Error message that indicates, that the text is missing in a badge component. Please supply an input text after the double colon.",

--- a/src/Components/Carousel.php
+++ b/src/Components/Carousel.php
@@ -193,7 +193,7 @@ class Carousel extends AbstractComponent {
 						'data-bs-slide-to' => $i,
 						'class'            => $class ?: false,
 						'aria-current'     => $class ? 'true' : false,
-						'aria-label'       => 'Slide ' . ( $i + 1 ),
+						'aria-label'       => wfMessage( 'bootstrap-components-carousel-slide-label', $i + 1 )->inContentLanguage()->text(),
 					]
 				) . PHP_EOL;
 			$class = false;


### PR DESCRIPTION
Make carousel indicator aria-label translatable.

The carousel indicator buttons emitted a hardcoded English "Slide N" aria-label regardless of wiki language. Resolve it through a new `bootstrap-components-carousel-slide-label` message in the content language, matching how other component controls (such as the alert close button) localise their aria-labels.

> <sub>AI-authored: Claude Code, `Opus 4.8`; detailed spec from @malberts, one clarifying question on test strategy; diff not yet human-reviewed; php -l and JSON valid, existing carousel indicator PHPUnit pins unchanged (English output identical); full MW-PHPUnit suite not run locally (no BootstrapComponents env), CI to exercise it.</sub>
