### PR TITLE
Prepare release 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Bootstrap Components is a [MediaWiki] extension that aims to provide
 editors with easy access to certain components introduced by
-[Twitter Bootstrap 4][Bootstrap].
+[Bootstrap 5][Bootstrap].
 
 Depending on your configuration, editors can utilize several
 _tag extensions_ and _parser functions_ inside wiki code to place certain

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,12 +2,17 @@
 
 ### BootstrapComponents 6.0.0
 
-Released on TBD
+Released on 16-July-2026
 
 Breaking changes:
 * requires MediaWiki 1.43 or later
 * requires PHP 8.1 or later
 * requires Bootstrap extension 6.x, which bundles Bootstrap library 5.3
+
+Changes:
+* change bootstrap foundation from version 4 to version 5.3
+* rewrite component JavaScript from jQuery to the native Bootstrap 5 API
+* reimplement the jumbotron using Bootstrap 5 utility classes, since Bootstrap 5 removed the .jumbotron component
 
 ### BootstrapComponents 5.2.4
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "BootstrapComponents",
-	"version": "6.0.0-dev",
+	"version": "6.0.0",
 	"author": [ "Tobias Oetterer" ],
 	"url": "https://www.mediawiki.org/wiki/Extension:BootstrapComponents",
 	"descriptionmsg": "bootstrap-components-desc",


### PR DESCRIPTION
Prepares the 6.0.0 release.

- Bump the `extension.json` version from `6.0.0-dev` to `6.0.0`.
- Set the 6.0.0 release-notes date and add its `Changes:` entry.
- Update the README description to reference Bootstrap 5 instead of Bootstrap 4.

The `Changes:` entry mirrors the last Bootstrap-major release (4.0.0): it leads with the foundation-version change plus the component-level changes that are not derivable from "moved to Bootstrap 5" (the jQuery-to-vanilla JS rewrite and the jumbotron reimplementation). Class and attribute renames are left to the migration guide, and there is no `Fixes:` section because every user-facing delta since 5.2.4 is the migration itself.

Otherwise scoped to the release metadata plus the README's "what it does" reference. The per-component docs were already updated for Bootstrap 5 during the migration; the historical migration guide and the BS3 legacy docs are intentionally left as-is.
