### PR TITLE
Link the README Packagist badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bootstrap Components
 [![Build Status](https://github.com/oetterer/BootstrapComponents/actions/workflows/ci.yml/badge.svg)](https://github.com/oetterer/BootstrapComponents/actions/workflows/ci.yml)
-![Latest Stable Version](https://img.shields.io/packagist/v/mediawiki/bootstrap-components.svg)
-![Total Download Count](https://img.shields.io/packagist/dt/mediawiki/bootstrap-components.svg)
+[![Latest Stable Version](https://img.shields.io/packagist/v/mediawiki/bootstrap-components.svg)](https://packagist.org/packages/mediawiki/bootstrap-components)
+[![Total Download Count](https://img.shields.io/packagist/dt/mediawiki/bootstrap-components.svg)](https://packagist.org/packages/mediawiki/bootstrap-components/stats)
 
 Bootstrap Components is a [MediaWiki] extension that aims to provide
 editors with easy access to certain components introduced by


### PR DESCRIPTION
Wrap the two Packagist badges in links so clicking them opens the relevant Packagist page:

- Latest Stable Version -> the package page (https://packagist.org/packages/mediawiki/bootstrap-components)
- Total Download Count -> the package's stats page (https://packagist.org/packages/mediawiki/bootstrap-components/stats), where the download figures live

The linked-badge approach follows the Chameleon skin's README; pointing the download badge at the stats page rather than the package page is a small refinement so the click lands on the data the badge summarizes. The badge images are unchanged (still shields.io); only the link wrappers are added.
