### PR TITLE
Skip loading Bootstrap when the active skin provides it

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -2,6 +2,29 @@
 Some components cause problems with other components or "external"
 elements.
 
+### Skins that load Bootstrap themselves
+Some skins put Bootstrap on the page on their own. For those, this extension does not
+request Extension:Bootstrap's `ext.bootstrap.styles`, since that would load Bootstrap's
+CSS twice. Chameleon, Medik and Tweeki are treated this way. Every other skin, Vector
+and Timeless among them, keeps getting Bootstrap from Extension:Bootstrap.
+
+Bootstrap's JavaScript is only partly covered by this. This extension stops requesting
+`ext.bootstrap.scripts` for those skins as well, but its own carousel, modal, popover
+and tooltip modules declare that module as a dependency, so a page using any of those
+components still loads it. On Chameleon that is harmless, because Chameleon pulls in
+the same module and ResourceLoader serves it once. On Medik and Tweeki it means
+Extension:Bootstrap's JavaScript runs alongside the skin's own bundled copy.
+
+With Medik and Tweeki, matching the Bootstrap versions is up to you. They bundle their
+own Bootstrap and declare no dependency on Extension:Bootstrap, so nothing checks that
+their Bootstrap matches the one this extension expects. BootstrapComponents 6.x targets
+Bootstrap 5.3, so pair it with a Bootstrap 5 release of these skins, and stay on
+BootstrapComponents 5.x for their Bootstrap 4 releases. Chameleon is not affected: it
+depends on Extension:Bootstrap itself, so Composer keeps the two in step.
+
+This extension cannot read the exact Bootstrap version a skin provides, so a mismatch
+surfaces as a component that looks or behaves wrong, not as an error message.
+
 ### Modals and popovers
 When you put popovers on a page with modals (or image modals),
 the modals break.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -8,12 +8,14 @@ request Extension:Bootstrap's `ext.bootstrap.styles`, since that would load Boot
 CSS twice. Chameleon, Medik and Tweeki are treated this way. Every other skin, Vector
 and Timeless among them, keeps getting Bootstrap from Extension:Bootstrap.
 
-Bootstrap's JavaScript is only partly covered by this. This extension stops requesting
-`ext.bootstrap.scripts` for those skins as well, but its own carousel, modal, popover
-and tooltip modules declare that module as a dependency, so a page using any of those
-components still loads it. On Chameleon that is harmless, because Chameleon pulls in
-the same module and ResourceLoader serves it once. On Medik and Tweeki it means
-Extension:Bootstrap's JavaScript runs alongside the skin's own bundled copy.
+Bootstrap's JavaScript is handled the same way, per skin. The carousel, modal, popover
+and tooltip modules depend on the active skin's own Bootstrap when it provides one, so
+Medik gets its `skins.medik.js` instead of Extension:Bootstrap's copy, and Chameleon
+shares the single `ext.bootstrap.scripts` it already loads. Tweeki is the exception: it
+bundles Bootstrap but exposes no `window.bootstrap` global for those modules' init
+scripts to reach, so it still loads Extension:Bootstrap's JavaScript alongside its own.
+Making Tweeki clean needs those init scripts to fall back to Bootstrap's jQuery plugin
+bridge.
 
 With Medik and Tweeki, matching the Bootstrap versions is up to you. They bundle their
 own Bootstrap and declare no dependency on Extension:Bootstrap, so nothing checks that
@@ -22,8 +24,10 @@ Bootstrap 5.3, so pair it with a Bootstrap 5 release of these skins, and stay on
 BootstrapComponents 5.x for their Bootstrap 4 releases. Chameleon is not affected: it
 depends on Extension:Bootstrap itself, so Composer keeps the two in step.
 
-This extension cannot read the exact Bootstrap version a skin provides, so a mismatch
-surfaces as a component that looks or behaves wrong, not as an error message.
+This extension cannot read the exact Bootstrap version a skin provides where it decides
+what to load, on the server. That version is only visible in the browser, too late to
+act on. So a mismatch surfaces as a component that looks or behaves wrong, not as an
+error message.
 
 ### Modals and popovers
 When you put popovers on a page with modals (or image modals),

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,7 @@ Changes:
 
 Fixes:
 * fix Bootstrap's CSS loading twice on the Chameleon, Medik, and Tweeki skins, which provide Bootstrap themselves
+* fix Bootstrap's JavaScript loading twice on the Medik skin, which broke its navbar and action dropdowns
 
 ### BootstrapComponents 6.0.0
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,9 @@ Changes:
 * add a migration guide for the Bootstrap 4 to 5 upgrade
 * split the migration guide into one document per upgrade and link both guides from the README
 
+Fixes:
+* fix Bootstrap's CSS loading twice on the Chameleon, Medik, and Tweeki skins, which provide Bootstrap themselves
+
 ### BootstrapComponents 6.0.0
 
 Released on 16-July-2026

--- a/extension.json
+++ b/extension.json
@@ -104,12 +104,12 @@
 			"styles": "ext.bootstrapComponents.card.fix.css"
 		},
 		"ext.bootstrapComponents.carousel.fix": {
-			"dependencies": "ext.bootstrap.scripts",
+			"class": "MediaWiki\\Extension\\BootstrapComponents\\ResourceLoader\\BootstrapDependentModule",
 			"styles": "ext.bootstrapComponents.carousel.fix.css",
 			"scripts": "ext.bootstrapComponents.carousel.js"
 		},
 		"ext.bootstrapComponents.modal.fix": {
-			"dependencies": "ext.bootstrap.scripts",
+			"class": "MediaWiki\\Extension\\BootstrapComponents\\ResourceLoader\\BootstrapDependentModule",
 			"styles": "ext.bootstrapComponents.modal.fix.css",
 			"scripts": "ext.bootstrapComponents.modal.js"
 		},
@@ -117,14 +117,14 @@
 			"styles": "ext.bootstrapComponents.modal.vector-fix.css"
 		},
 		"ext.bootstrapComponents.popover.fix": {
-			"dependencies": "ext.bootstrap.scripts",
+			"class": "MediaWiki\\Extension\\BootstrapComponents\\ResourceLoader\\BootstrapDependentModule",
 			"scripts": "ext.bootstrapComponents.popover.js"
 		},
 		"ext.bootstrapComponents.popover.vector-fix": {
 			"styles": "ext.bootstrapComponents.popover.vector-fix.css"
 		},
 		"ext.bootstrapComponents.tooltip.fix": {
-			"dependencies": "ext.bootstrap.scripts",
+			"class": "MediaWiki\\Extension\\BootstrapComponents\\ResourceLoader\\BootstrapDependentModule",
 			"scripts": "ext.bootstrapComponents.tooltip.js",
 			"styles": "ext.bootstrapComponents.tooltip.fix.css"
 		},

--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -40,6 +40,13 @@ use MediaWiki\Output\OutputPage;
  */
 class OutputPageParserOutput {
 
+	/**
+	 * Skins that put Bootstrap on the page themselves, either by bundling their own copy
+	 * or, in Chameleon's case, by registering Extension:Bootstrap's modules under a
+	 * different name that ResourceLoader cannot deduplicate against ext.bootstrap.*.
+	 */
+	private const SKINS_LOADING_BOOTSTRAP_THEMSELVES = [ 'chameleon', 'medik', 'tweeki' ];
+
 	public function __construct(
 		private readonly OutputPage $outputPage,
 		private readonly BootstrapComponentsService $bootstrapComponentService,
@@ -50,9 +57,26 @@ class OutputPageParserOutput {
 	 * @return void
 	 */
 	public function process(): void {
+		$this->addBootstrapModules();
+
 		if ( $this->getBootstrapComponentsService()->vectorSkinInUse() ) {
 			$this->getOutputPage()->addModules( [ 'ext.bootstrapComponents.vector-fix' ] );
 		}
+	}
+
+	private function addBootstrapModules(): void {
+		if ( $this->activeSkinLoadsBootstrapItself() ) {
+			return;
+		}
+
+		$this->getOutputPage()->addModuleStyles( [ 'ext.bootstrap.styles' ] );
+		$this->getOutputPage()->addModules( [ 'ext.bootstrap.scripts' ] );
+	}
+
+	private function activeSkinLoadsBootstrapItself(): bool {
+		$activeSkin = strtolower( $this->getOutputPage()->getSkin()->getSkinName() ?? '' );
+
+		return in_array( $activeSkin, self::SKINS_LOADING_BOOTSTRAP_THEMSELVES, true );
 	}
 
 	protected function getBootstrapComponentsService(): BootstrapComponentsService {

--- a/src/Hooks/OutputPageParserOutput.php
+++ b/src/Hooks/OutputPageParserOutput.php
@@ -45,7 +45,7 @@ class OutputPageParserOutput {
 	 * or, in Chameleon's case, by registering Extension:Bootstrap's modules under a
 	 * different name that ResourceLoader cannot deduplicate against ext.bootstrap.*.
 	 */
-	private const SKINS_LOADING_BOOTSTRAP_THEMSELVES = [ 'chameleon', 'medik', 'tweeki' ];
+	private const BOOTSTRAP_SKINS = [ 'chameleon', 'medik', 'tweeki' ];
 
 	public function __construct(
 		private readonly OutputPage $outputPage,
@@ -76,7 +76,7 @@ class OutputPageParserOutput {
 	private function activeSkinLoadsBootstrapItself(): bool {
 		$activeSkin = strtolower( $this->getOutputPage()->getSkin()->getSkinName() ?? '' );
 
-		return in_array( $activeSkin, self::SKINS_LOADING_BOOTSTRAP_THEMSELVES, true );
+		return in_array( $activeSkin, self::BOOTSTRAP_SKINS, true );
 	}
 
 	protected function getBootstrapComponentsService(): BootstrapComponentsService {

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -197,8 +197,6 @@ class HooksHandler implements
 		// once, this was only loaded, when a component was paced on the page. now, we load it always
 		// to keep the layout of all the wiki pages consistent.
 		$parser->getOutput()->addModuleStyles( [ 'ext.bootstrapComponents.bootstrap.fix' ] );
-		$parser->getOutput()->addModuleStyles( [ 'ext.bootstrap.styles' ] );
-		$parser->getOutput()->addModules( [ 'ext.bootstrap.scripts' ] );
 		$skin = $this->getBootstrapComponentsService()->getNameOfActiveSkin();
 		foreach ( $this->getBootstrapComponentsService()->getActiveComponents() as $activeComponent ) {
 			if ( !$this->getComponentLibrary()->isRegistered( $activeComponent ) ) {

--- a/src/ResourceLoader/BootstrapDependentModule.php
+++ b/src/ResourceLoader/BootstrapDependentModule.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace MediaWiki\Extension\BootstrapComponents\ResourceLoader;
+
+use MediaWiki\ResourceLoader\Context;
+use MediaWiki\ResourceLoader\FileModule;
+
+/**
+ * Adds the active skin's Bootstrap scripts module as a dependency: the skin's own module when it
+ * ships Bootstrap, otherwise ext.bootstrap.scripts. It is a dependency, rather than merely present
+ * on the page, because the component init scripts call the Bootstrap global and must load after it.
+ */
+class BootstrapDependentModule extends FileModule {
+
+	private const DEFAULT_BOOTSTRAP_SCRIPTS_MODULE = 'ext.bootstrap.scripts';
+
+	/** Skins that bundle Bootstrap and expose the window.bootstrap global, mapped to their scripts module. */
+	private const BOOTSTRAP_SCRIPTS_MODULE_BY_SKIN = [
+		'medik' => 'skins.medik.js',
+	];
+
+	/** @inheritDoc */
+	public function getDependencies( ?Context $context = null ) {
+		$skin = $context?->getSkin() ?? '';
+		$bootstrap = self::BOOTSTRAP_SCRIPTS_MODULE_BY_SKIN[ $skin ] ?? self::DEFAULT_BOOTSTRAP_SCRIPTS_MODULE;
+
+		return array_merge( parent::getDependencies( $context ), [ $bootstrap ] );
+	}
+}

--- a/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/Hooks/OutputPageParserOutputTest.php
@@ -2,10 +2,12 @@
 
 namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\Hooks;
 
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
 use MediaWiki\Output\OutputPage;
 use PHPUnit\Framework\TestCase;
+use Skin;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput
@@ -37,33 +39,81 @@ class OutputPageParserOutputTest extends TestCase {
 		);
 	}
 
-	public function testHookOutputPageParserOutputLoadsVectorFixUnderVector() {
-		$outputPage = $this->createMock( OutputPage::class );
-		$outputPage->expects( $this->never() )->method( 'addHTML' );
-		$outputPage->expects( $this->once() )
-			->method( 'addModules' )
-			->with(
-				$this->equalTo( [ 'ext.bootstrapComponents.vector-fix' ] )
-			);
+	public function testAddsBootstrapStylesForSkinWithoutOwnBootstrap() {
+		$outputPage = $this->newOutputPageForSkin( 'monobook' );
 
-		$bootstrapService = $this->createMock( BootstrapComponentsService::class );
-		$bootstrapService->expects( $this->once() )
-			->method( 'vectorSkinInUse' )
-			->willReturn( true );
+		$this->process( $outputPage, vectorSkinInUse: false );
 
-		$instance = new OutputPageParserOutput( $outputPage, $bootstrapService );
-		$instance->process();
+		$this->assertContains( 'ext.bootstrap.styles', $outputPage->getModuleStyles() );
 	}
 
-	public function testHookDoesNothingWhenNotVector() {
-		$outputPage = $this->createMock( OutputPage::class );
-		$outputPage->expects( $this->never() )->method( 'addHTML' );
-		$outputPage->expects( $this->never() )->method( 'addModules' );
+	public function testAddsBootstrapScriptsForSkinWithoutOwnBootstrap() {
+		$outputPage = $this->newOutputPageForSkin( 'monobook' );
 
+		$this->process( $outputPage, vectorSkinInUse: false );
+
+		$this->assertContains( 'ext.bootstrap.scripts', $outputPage->getModules() );
+	}
+
+	/**
+	 * @dataProvider skinLoadingBootstrapItselfProvider
+	 */
+	public function testOmitsBootstrapStylesForSkinLoadingBootstrapItself( string $skinName ) {
+		$outputPage = $this->newOutputPageForSkin( $skinName );
+
+		$this->process( $outputPage, vectorSkinInUse: false );
+
+		$this->assertNotContains( 'ext.bootstrap.styles', $outputPage->getModuleStyles() );
+	}
+
+	/**
+	 * @dataProvider skinLoadingBootstrapItselfProvider
+	 */
+	public function testOmitsBootstrapScriptsForSkinLoadingBootstrapItself( string $skinName ) {
+		$outputPage = $this->newOutputPageForSkin( $skinName );
+
+		$this->process( $outputPage, vectorSkinInUse: false );
+
+		$this->assertNotContains( 'ext.bootstrap.scripts', $outputPage->getModules() );
+	}
+
+	public static function skinLoadingBootstrapItselfProvider(): array {
+		return [
+			'chameleon' => [ 'chameleon' ],
+			'medik' => [ 'medik' ],
+			'tweeki' => [ 'tweeki' ],
+		];
+	}
+
+	public function testHookOutputPageParserOutputLoadsVectorFixUnderVector() {
+		$outputPage = $this->newOutputPageForSkin( 'vector' );
+
+		$this->process( $outputPage, vectorSkinInUse: true );
+
+		$this->assertContains( 'ext.bootstrapComponents.vector-fix', $outputPage->getModules() );
+	}
+
+	public function testOmitsVectorFixWhenVectorIsNotInUse() {
+		$outputPage = $this->newOutputPageForSkin( 'monobook' );
+
+		$this->process( $outputPage, vectorSkinInUse: false );
+
+		$this->assertNotContains( 'ext.bootstrapComponents.vector-fix', $outputPage->getModules() );
+	}
+
+	private function newOutputPageForSkin( string $skinName ): OutputPage {
+		$skin = $this->createMock( Skin::class );
+		$skin->method( 'getSkinName' )->willReturn( $skinName );
+
+		$context = new RequestContext();
+		$context->setSkin( $skin );
+
+		return new OutputPage( $context );
+	}
+
+	private function process( OutputPage $outputPage, bool $vectorSkinInUse ): void {
 		$bootstrapService = $this->createMock( BootstrapComponentsService::class );
-		$bootstrapService->expects( $this->once() )
-			->method( 'vectorSkinInUse' )
-			->willReturn( false );
+		$bootstrapService->method( 'vectorSkinInUse' )->willReturn( $vectorSkinInUse );
 
 		$instance = new OutputPageParserOutput( $outputPage, $bootstrapService );
 		$instance->process();

--- a/tests/phpunit/Unit/ResourceLoader/BootstrapDependentModuleTest.php
+++ b/tests/phpunit/Unit/ResourceLoader/BootstrapDependentModuleTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace MediaWiki\Extension\BootstrapComponents\Tests\Unit\ResourceLoader;
+
+use MediaWiki\Extension\BootstrapComponents\ResourceLoader\BootstrapDependentModule;
+use MediaWiki\ResourceLoader\Context;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MediaWiki\Extension\BootstrapComponents\ResourceLoader\BootstrapDependentModule
+ *
+ * @group extension-bootstrap-components
+ * @group mediawiki-databaseless
+ *
+ * @license GNU GPL v3+
+ */
+class BootstrapDependentModuleTest extends TestCase {
+
+	public function testAddsTheSkinsOwnBootstrapModuleWhenTheSkinShipsOne() {
+		$module = $this->newModuleWithDependencies( [ 'some.other.module' ] );
+
+		$dependencies = $module->getDependencies( $this->newContextForSkin( 'medik' ) );
+
+		$this->assertContains( 'skins.medik.js', $dependencies );
+		$this->assertNotContains( 'ext.bootstrap.scripts', $dependencies );
+		$this->assertContains( 'some.other.module', $dependencies );
+	}
+
+	/**
+	 * @dataProvider skinWithoutReachableOwnBootstrapProvider
+	 */
+	public function testAddsExtBootstrapScriptsForOtherSkins( string $skin ) {
+		$module = $this->newModuleWithDependencies( [] );
+
+		$this->assertSame(
+			[ 'ext.bootstrap.scripts' ],
+			$module->getDependencies( $this->newContextForSkin( $skin ) )
+		);
+	}
+
+	public static function skinWithoutReachableOwnBootstrapProvider(): array {
+		return [
+			'vector' => [ 'vector' ],
+			'chameleon' => [ 'chameleon' ],
+			'tweeki' => [ 'tweeki' ],
+			'monobook' => [ 'monobook' ],
+		];
+	}
+
+	public function testAddsExtBootstrapScriptsWhenNoSkinContext() {
+		$module = $this->newModuleWithDependencies( [] );
+
+		$this->assertSame( [ 'ext.bootstrap.scripts' ], $module->getDependencies() );
+	}
+
+	private function newModuleWithDependencies( array $dependencies ): BootstrapDependentModule {
+		return new BootstrapDependentModule( [ 'dependencies' => $dependencies ] );
+	}
+
+	private function newContextForSkin( string $skin ): Context {
+		$context = $this->createMock( Context::class );
+		$context->method( 'getSkin' )->willReturn( $skin );
+		return $context;
+	}
+}


### PR DESCRIPTION
For https://github.com/oetterer/BootstrapComponents/issues/70

Skins that put Bootstrap on the page themselves ended up loading a second copy
from Extension:Bootstrap, once for the stylesheet and once for the script. This
fixes both.

## Bootstrap CSS

Extension:Bootstrap's `ext.bootstrap.styles` and `ext.bootstrap.scripts` were
added in `ParserAfterParse`. That is the parse phase, so the decision is baked
into the skin-agnostic parser cache and cannot depend on the skin. They are now
added in the `OutputPageParserOutput` hook, where the active skin is known, and
skipped for skins that put Bootstrap on the page themselves. The list of those
skins is internal (Chameleon, Medik, Tweeki) rather than configurable, since
whether a skin loads its own Bootstrap is a fact about the skin, not a per-wiki
policy.

Extension:Bootstrap stays a Composer `require`. That keeps a useful lever: the
version constraint on it (`^6.0`, i.e. Bootstrap 5.3) pins the Bootstrap this
extension loads for skins that get it from Extension:Bootstrap, and rejects a
future Extension:Bootstrap that moves to a newer Bootstrap. Self-bundling skins
declare no such dependency, so matching their bundled Bootstrap stays the
operator's responsibility (see the known issues). The init gate is untouched,
and `SetupAfterCache` / `addAllBootstrapModules()` is untouched: that call only
configures what Extension:Bootstrap compiles into `ext.bootstrap.styles`, it
puts nothing on a page. Not skipping remains the safe default, so skipping is an
optimisation rather than a load-bearing correctness decision.

### Evidence (CSS)

Distinct stylesheets delivering the Bootstrap library, per skin.

| Skin | Before | After |
| --- | --- | --- |
| chameleon | `ext.bootstrap.styles` + `zzz.ext.bootstrap.styles` (2) | `zzz.ext.bootstrap.styles` (1) |
| medik | `ext.bootstrap.styles` + `skins.medik` (2) | `skins.medik` (1) |
| tweeki | `ext.bootstrap.styles` + `skins.tweeki.styles` (2) | `skins.tweeki.styles` (1) |
| vector | `ext.bootstrap.styles` (1) | `ext.bootstrap.styles` (1) |
| vector-2022 | `ext.bootstrap.styles` (1) | `ext.bootstrap.styles` (1) |
| monobook | `ext.bootstrap.styles` (1) | `ext.bootstrap.styles` (1) |
| timeless | `ext.bootstrap.styles` (1) | `ext.bootstrap.styles` (1) |

Chameleon's double request, the case reported in the issue, is gone:

```
before:  load.php?...modules=ext.bootstrap.styles&only=styles&skin=chameleon
         load.php?...modules=zzz.ext.bootstrap.styles&only=styles&skin=chameleon
after:   load.php?...modules=zzz.ext.bootstrap.styles&only=styles&skin=chameleon
```

## Bootstrap JavaScript

The CSS skip alone does not keep Extension:Bootstrap's JavaScript off a
self-bundling skin. `ext.bootstrapComponents.carousel.fix`, `.modal.fix`,
`.popover.fix` and `.tooltip.fix` each ship an init script that calls the
Bootstrap JavaScript global (`new bootstrap.Carousel( ... )`,
`bootstrap.Modal.getOrCreateInstance( ... )`, and so on), so each declared
`ext.bootstrap.scripts` as a ResourceLoader dependency to guarantee Bootstrap
loads first. That dependency is load-bearing, dropping it would let the init
script run before Bootstrap exists, but it also forced Extension:Bootstrap's
copy onto every skin. On a skin that bundles its own Bootstrap the page then
carried two copies, and because each registers Bootstrap's data-api on the
document, one click was handled twice: a navbar or action dropdown opened and
immediately closed.

A ResourceLoader dependency cannot be varied per skin in static
`extension.json`, but it can in a module class. The four modules now use
`BootstrapDependentModule` and declare no Bootstrap dependency of their own; its
`getDependencies( ?Context )` supplies one per skin: the skin's own scripts
module when it bundles Bootstrap, otherwise `ext.bootstrap.scripts`. The map
currently gives `medik` its `skins.medik.js`. Other skins get
`ext.bootstrap.scripts`; Chameleon adds it itself under the same name, so
ResourceLoader deduplicates it and its JavaScript was never doubled.

The map is a skin list rather than automatic detection because a skin's bundled
Bootstrap version is not knowable server-side, where the module-loading decision
is made. It is only visible in the browser (`window.bootstrap.VERSION`), which is
too late to change what loads.

### Evidence (JS)

Verified in a browser (automated, Playwright) on Vector, Chameleon, Medik and
Tweeki:

- Medik: `ext.bootstrap.scripts` is no longer loaded (its module state stays
  `registered`); the page carries one Bootstrap, Medik's own, delivered with
  `skins.medik.js`. The three skin-emitted chrome dropdowns, user menu, Actions
  (edit / history / source) and Tools, open and stay open. Force-loading
  `ext.bootstrap.scripts` to recreate the previous double makes all three open
  and immediately close again, so the single-Bootstrap state is what fixes them.
  Carousel, modal, popover, tooltip and accordion all work, and no
  `bootstrap ... is not available` warning appears, so the init scripts still
  reach the global.
- Vector and Chameleon: unchanged, one Bootstrap, components and dropdowns
  working.

### Tweeki is not covered yet

Tweeki bundles its own Bootstrap but exposes no `window.bootstrap` global, only
Bootstrap's jQuery plugin bridge. The four init scripts reach Bootstrap only
through the global, so pointing Tweeki's dependency at its own module would leave
them unable to initialise those components. Tweeki therefore stays on
`ext.bootstrap.scripts` and still double-loads Bootstrap's JavaScript (confirmed
in the browser: two live copies, seen as two modal backdrops). Making Tweeki
clean needs the init scripts to fall back to the jQuery bridge when the global is
absent, which is a separate change.

## Known behaviour change: `action=parse` without `useskin`

`ext.bootstrap.styles` and `ext.bootstrap.scripts` used to sit on the
`ParserOutput`, which travels with the parsed content. They now sit on the
`OutputPage`, which only exists when a page is rendered for a skin. So
`api.php?action=parse` without a `useskin` parameter no longer lists them. The
scripts still reach any caller that loads the carousel, modal, popover or
tooltip fix modules, since with no skin those resolve to `ext.bootstrap.scripts`.
The styles have no such dependency, so they simply go missing.

With `useskin` the hook runs and the answer is correct per skin, which is an
improvement on master: master answered the same way for every skin, so on a
Chameleon wiki it told callers to load Bootstrap that Chameleon already provides.

Ordinary page views are unaffected and no known caller depends on this, so it is
left as-is for now.

## Tests

`OutputPageParserOutputTest` asserts the CSS outcome on a real `OutputPage`:
`ext.bootstrap.styles` and `ext.bootstrap.scripts` are present in its module
lists for a skin that does not load Bootstrap, and absent for chameleon, medik
and tweeki. Asserting the resulting module list rather than the calls made to a
mock keeps the tests meaningful across a refactor of how the modules get added.

`BootstrapDependentModuleTest` asserts the outcome directly on the module:
`getDependencies` adds `skins.medik.js` under the medik skin and
`ext.bootstrap.scripts` for vector, chameleon, tweeki and monobook and when no
skin context is available, alongside any other dependencies the module declares.

> <sub>AI-authored — Claude Code, `Opus 4.8`; agreed design with @malberts, the JavaScript half steered across many rounds; code diff not yet human-reviewed; verified in a browser (CSS across seven skins; JavaScript across vector/chameleon/medik/tweeki, including Medik's real navbar/action dropdowns against a force-loaded second Bootstrap) plus unit tests; phpcs not run locally, pending on CI.</sub>
