### PR TITLE
Fix inaccuracies in the Bootstrap 5 migration guide

### DIFF
--- a/docs/migration-guide-bs5.md
+++ b/docs/migration-guide-bs5.md
@@ -37,7 +37,7 @@ need review. The changes most likely to matter:
 | `badge-{color}` | `text-bg-{color}` |
 | `badge-pill` | `rounded-pill` |
 | `jumbotron` | `p-5 mb-4 bg-body-tertiary rounded-3` |
-| carousel indicators as `<ol>`/`<li>` | `<button>` elements |
+| `ol.carousel-indicators` with `<li>` children | `div.carousel-indicators` with `<button>` children |
 
 ### Hand-written Bootstrap HTML in templates
 

--- a/docs/migration-guide-bs5.md
+++ b/docs/migration-guide-bs5.md
@@ -72,7 +72,7 @@ Pages rendered before the upgrade still carry Bootstrap 4 markup in the
 parser cache while the wiki already serves Bootstrap 5 CSS and
 JavaScript, so components on cached pages can look broken. This
 resolves as pages re-render; to force it, purge the affected pages or
-run the `purgeParserCache` maintenance script.
+run `purgeParserCache.php --age 0` to clear the parser cache.
 
 [BS5-jumbotron]: https://getbootstrap.com/docs/5.3/examples/jumbotron/
 [BS5-migration]: https://getbootstrap.com/docs/5.3/migration/


### PR DESCRIPTION
Follows-up to https://github.com/oetterer/BootstrapComponents/pull/114, and is based on that branch so the corrections land with it.

Two claims in the new guide do not match the 6.0.0 source.

**Carousel indicators.** Only the children became buttons. `Carousel.php` renders `div.carousel-indicators` where it used to render `ol.carousel-indicators`, so the class survives and the element changes. A reader following the old row rewrites toward a selector that matches nothing. The extension's own stylesheet had to make this exact edit, `.carousel ol.carousel-indicators` to `.carousel .carousel-indicators`, so the affected selector shape is one that exists in the wild.

**purgeParserCache.** Run bare, the script exits with `Must specify either --expiredate or --age`. Passing `--age 0` deletes every object created more than zero seconds ago, which reaches the whole parser cache because `CacheTime` caps each entry's expiry at `$wgParserCacheExpireTime`.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; two findings from a local review of #114, picked by @malberts, a third dropped at their call; diff not yet human-reviewed; each claim checked against the 6.0.0 source and MediaWiki 1.43 core, docs only so no tests.</sub>
