### PR TITLE
Show a runnable purgeParserCache invocation

### DIFF
--- a/docs/migration-guide-bs5.md
+++ b/docs/migration-guide-bs5.md
@@ -72,7 +72,12 @@ Pages rendered before the upgrade still carry Bootstrap 4 markup in the
 parser cache while the wiki already serves Bootstrap 5 CSS and
 JavaScript, so components on cached pages can look broken. This
 resolves as pages re-render; to force it, purge the affected pages or
-run the `purgeParserCache` maintenance script.
+clear the whole parser cache with the `purgeParserCache` maintenance
+script:
+
+```
+php maintenance/run.php purgeParserCache --age 0
+```
 
 [BS5-jumbotron]: https://getbootstrap.com/docs/5.3/examples/jumbotron/
 [BS5-migration]: https://getbootstrap.com/docs/5.3/migration/


### PR DESCRIPTION
Follows-up to https://github.com/oetterer/BootstrapComponents/pull/114, and is based on that branch so the fix lands with it.

Run bare, `purgeParserCache` exits with `Must specify either --expiredate or --age` on every MediaWiki version the extension supports (checked 1.43 through master). Spell out an invocation that works: `--age 0` deletes every parser cache entry saved before the run, since entry expiry is capped at `$wgParserCacheExpireTime`. Also say the script clears the whole parser cache, not only the affected pages.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; re-review of #114 requested by @malberts, no revisions; diff not yet human-reviewed; claim checked against MediaWiki 1.43–master source, and both invocations run on a real 1.43 install (bare one fails, documented one completes); docs only, so no tests.</sub>

<details><summary>Production notes</summary>

Independent re-run of the #114 review in a clean session; reproduces the purgeParserCache fix from closed #115 but not its carousel-indicators edit, which two independent reviewers this round rated accurate as written and low-impact.

</details>
