### PR TITLE
Fix broken Lua example and Bootstrap 3 doc links

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,4 +114,4 @@ public function placeMe( $input ) {
 [classComponentLibrary]: ../src/ComponentLibrary.php
 [qqq.json]: ../i18n/qqq.json
 [en.json]: ../i18n/en.json
-[components.md]: bs3/components.md
+[components.md]: components.md

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -128,7 +128,7 @@ galleries, please visit [mediawiki.org][Gallery].
 [Git]: https://git-scm.com/
 [GitArchive]: https://github.com/oetterer/BootstrapComponents/archive/master.zip
 [BootstrapExtension]: https://www.mediawiki.org/wiki/Extension:Bootstrap
-[Components]: bs3/components.md
+[Components]: components.md
 [known-issues]: known-issues.md
 [ImageHelp]: https://www.mediawiki.org/wiki/Help:Images
 [Gallery]: https://www.mediawiki.org/wiki/Help:Images#Rendering_a_gallery_of_images

--- a/docs/lua.md
+++ b/docs/lua.md
@@ -71,11 +71,11 @@ like this
 
 ```lua
 local tooltip = mw.bootstrap.parse( 'tooltip', 'ambiguous', { text='better explanation' } )
-local inner = [[<bootstrap_card heading="Headline for Card1">Text inside the card</bootstrap_panel>
-    <bootstrap_card heading="Headline for Card2">Text inside the card</bootstrap_panel>
-    <bootstrap_card heading="Headline for Card3" color="danger" active>Text inside the card]] .. tooltip ..  [[</bootstrap_panel>
-    <bootstrap_card heading="Headline for Card4" color="info">Text inside the card</bootstrap_panel>
-    <bootstrap_card color="info">Text inside the card</bootstrap_panel>]]
+local inner = [[<bootstrap_card heading="Headline for Card1">Text inside the card</bootstrap_card>
+    <bootstrap_card heading="Headline for Card2">Text inside the card</bootstrap_card>
+    <bootstrap_card heading="Headline for Card3" color="danger" active>Text inside the card]] .. tooltip ..  [[</bootstrap_card>
+    <bootstrap_card heading="Headline for Card4" color="info">Text inside the card</bootstrap_card>
+    <bootstrap_card color="info">Text inside the card</bootstrap_card>]]
 return mw.bootstrap.parse(
     'accordion',
     inner,

--- a/docs/lua.md
+++ b/docs/lua.md
@@ -110,4 +110,4 @@ end
 ```
 
 [Scribunto]: https://www.mediawiki.org/wiki/Extension:Scribunto
-[components]: bs3/components.md
+[components]: components.md


### PR DESCRIPTION
Two small documentation fixes found while auditing the docs against the current code.

**The Lua accordion example did not parse.** The workaround example in `docs/lua.md` opened each pane
with `<bootstrap_card>` but closed it with `</bootstrap_panel>`, a leftover from the panel-to-card
rename. MediaWiki matches tag extensions by name, so the example was broken. `heading` is left as is,
since it is a valid alias for `header`.

**Component links pointed at the Bootstrap 3 archive.** `lua.md`, `installation-configuration.md` and
`contributing.md` all linked "components" to `bs3/components.md` rather than the current
`docs/components.md`. `contributing.md` was telling contributors to document new components in the
archive.

> <sub>AI-authored, Claude Code, `Opus 4.8 (max)`; found in an audit and fixed at @malberts's
> direction; diff not yet human-reviewed; the tag mismatch and the link targets were checked against
> the current component definitions and docs.</sub>
