### PR TITLE
Use Bootstrap 5 --bs- CSS variable names in button and card colours

### DIFF
--- a/modules/ext.bootstrapComponents.button.fix.css
+++ b/modules/ext.bootstrapComponents.button.fix.css
@@ -74,7 +74,7 @@ a.btn-dark:link,
 a.btn-dark:visited,
 a.btn-dark:active,
 a.btn-dark:hover {
-    color: var(--white);
+    color: var(--bs-white);
 }
 
 /**
@@ -89,7 +89,7 @@ a.btn-outline-light,
 a.btn-outline-light:link,
 a.btn-outline-light:visited,
 a.btn-outline-light:active {
-	color: var(--white);
+	color: var(--bs-white);
 }
 a.btn-outline-default:hover,
 a.btn-outline-light:hover {
@@ -100,47 +100,47 @@ a.btn-outline-primary,
 a.btn-outline-primary:link,
 a.btn-outline-primary:visited,
 a.btn-outline-primary:active {
-	color: var(--primary);
+	color: var(--bs-primary);
 }
 a.btn-outline-primary:hover {
-	color: var(--white);
+	color: var(--bs-white);
 }
 
 a.btn-outline-secondary,
 a.btn-outline-secondary:link,
 a.btn-outline-secondary:visited,
 a.btn-outline-secondary:active {
-	color: var(--secondary);
+	color: var(--bs-secondary);
 }
 a.btn-outline-secondary:hover {
-	color: var(--white);
+	color: var(--bs-white);
 }
 
 a.btn-outline-success,
 a.btn-outline-success:link,
 a.btn-outline-success:visited,
 a.btn-outline-success:active {
-	color: var(--success);
+	color: var(--bs-success);
 }
 a.btn-outline-success:hover {
-	color: var(--white);
+	color: var(--bs-white);
 }
 
 a.btn-outline-danger,
 a.btn-outline-danger:link,
 a.btn-outline-danger:visited,
 a.btn-outline-danger:active {
-	color: var(--danger);
+	color: var(--bs-danger);
 }
 a.btn-outline-danger:hover {
-	color: var(--white);
+	color: var(--bs-white);
 }
 
 a.btn-outline-warning,
 a.btn-outline-warning:link,
 a.btn-outline-warning:visited,
 a.btn-outline-warning:active {
-	color: var(--warning);
+	color: var(--bs-warning);
 }
 a.btn-outline-warning:hover {
 	color: #212529;
@@ -150,18 +150,18 @@ a.btn-outline-info,
 a.btn-outline-info:link,
 a.btn-outline-info:visited,
 a.btn-outline-info:active {
-	color: var(--info);
+	color: var(--bs-info);
 }
 a.btn-outline-info:hover {
-	color: var(--white);
+	color: var(--bs-white);
 }
 
 a.btn-outline-dark,
 a.btn-outline-dark:link,
 a.btn-outline-dark:visited,
 a.btn-outline-dark:active {
-	color: var(--dark);
+	color: var(--bs-dark);
 }
 a.btn-outline-dark:hover {
-	color: var(--white);
+	color: var(--bs-white);
 }

--- a/modules/ext.bootstrapComponents.card.fix.css
+++ b/modules/ext.bootstrapComponents.card.fix.css
@@ -23,5 +23,5 @@
  * @author        Tobias Oetterer
  */
 .text-white .card-header .card-title {
-	color: var(--white);
+	color: var(--bs-white);
 }


### PR DESCRIPTION
## Problem

Under Bootstrap 5, anchor-based buttons and colour-background cards render with near-black text on a coloured fill.

`modules/ext.bootstrapComponents.button.fix.css` and `modules/ext.bootstrapComponents.card.fix.css` set the text colour of anchor buttons and coloured cards using Bootstrap's colour CSS custom properties, but with the Bootstrap 4 names (`var(--white)`, `var(--primary)`, and so on). Bootstrap 5 prefixes all of its CSS custom properties with `--bs-` (`--bs-white`, `--bs-primary`, …), so the unprefixed names are undefined. The `color` declaration is then invalid at computed-value time and the element falls back to the inherited near-black body colour, giving near-black text on a blue or otherwise coloured button or card.

This affects the collapse trigger, `{{#bootstrap_button}}`, popover triggers, the ImageModal "view source" button, and cards with a `background` colour.

## Fix

Rename the referenced colour custom properties to their Bootstrap 5 `--bs-` names in both files. The literal `#212529` values on `btn-default` / `btn-light` (dark text on a light fill) are intentional and unchanged. No other files are touched.

Verified end-to-end on a Bootstrap 5 wiki: the affected buttons render white on their coloured fill after the change.

> <sub>AI-authored with Claude Code, `Opus 4.8 (1M context)`; diagnosed from a live black-on-blue button and fixed at @malberts's request; verified end-to-end on a Bootstrap 5 test wiki; not yet human-reviewed.</sub>
