### PR TITLE
Prepare release 6.0.1

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,7 +2,10 @@
 
 ### BootstrapComponents 6.0.1
 
-Released on TBD
+Released on 20-July-2026
+
+Fixes:
+* fix text color on anchor-based buttons and colored cards
 
 Changes:
 * add a migration guide for the Bootstrap 4 to 5 upgrade

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "BootstrapComponents",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"author": [ "Tobias Oetterer" ],
 	"url": "https://www.mediawiki.org/wiki/Extension:BootstrapComponents",
 	"descriptionmsg": "bootstrap-components-desc",


### PR DESCRIPTION
Prepares the BootstrapComponents 6.0.1 release.

- Bumps `extension.json` to `6.0.1`.
- Dates the 6.0.1 release notes (20-July-2026) and adds the fix for near-black text on anchor-based buttons and coloured cards under Bootstrap 5 (they referenced the Bootstrap 4 CSS variable names that Bootstrap 5 renamed with a `--bs-` prefix).

The 6.0.1 line already carried the migration-guide documentation changes; this finalises the version and release date.

> <sub>AI-authored with Claude Code, `Opus 4.8 (1M context)`; release preparation at @malberts's request, mirroring the prior "Prepare release" commits; not yet human-reviewed.</sub>
