### PR TITLE
Load Bootstrap once per skin

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,16 @@
 ## Release Notes
 
+### BootstrapComponents 6.1.0
+
+Released on TBD
+
+Fixes:
+* fix BootstrapComponents on skins that bundle their own Bootstrap, such as Medik and Tweeki: the second Bootstrap copy broke their navbar and action dropdowns and left stray list bullets on the sidebar and menus, and is no longer loaded
+
+Changes:
+* Bootstrap from Extension:Bootstrap is now loaded only on skins that do not provide their own
+* `api.php?action=parse` no longer lists `ext.bootstrap.styles` and `ext.bootstrap.scripts`; they load at page render instead, so page views, VisualEditor and live preview are unaffected
+
 ### BootstrapComponents 6.0.1
 
 Released on 20-July-2026

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "BootstrapComponents",
-	"version": "6.0.1",
+	"version": "6.1.0",
 	"author": [ "Tobias Oetterer" ],
 	"url": "https://www.mediawiki.org/wiki/Extension:BootstrapComponents",
 	"descriptionmsg": "bootstrap-components-desc",
@@ -33,6 +33,9 @@
 		}
 	},
 	"Hooks": {
+		"BeforePageDisplay": {
+			"handler": "BootStrapHooks"
+		},
 		"GalleryGetModes": {
 			"handler": "BootStrapHooks"
 		},
@@ -91,6 +94,9 @@
 		"ext.bootstrapComponents.bootstrap.fix": {
 			"styles": "ext.bootstrapComponents.bootstrap.fix.css"
 		},
+		"ext.bootstrapComponents.bootstrap": {
+			"scripts": "ext.bootstrapComponents.bootstrap.js"
+		},
 		"ext.bootstrapComponents.accordion.fix": {
 			"styles": "ext.bootstrapComponents.accordion.fix.css"
 		},
@@ -104,12 +110,12 @@
 			"styles": "ext.bootstrapComponents.card.fix.css"
 		},
 		"ext.bootstrapComponents.carousel.fix": {
-			"dependencies": "ext.bootstrap.scripts",
+			"dependencies": "ext.bootstrapComponents.bootstrap",
 			"styles": "ext.bootstrapComponents.carousel.fix.css",
 			"scripts": "ext.bootstrapComponents.carousel.js"
 		},
 		"ext.bootstrapComponents.modal.fix": {
-			"dependencies": "ext.bootstrap.scripts",
+			"dependencies": "ext.bootstrapComponents.bootstrap",
 			"styles": "ext.bootstrapComponents.modal.fix.css",
 			"scripts": "ext.bootstrapComponents.modal.js"
 		},
@@ -117,14 +123,14 @@
 			"styles": "ext.bootstrapComponents.modal.vector-fix.css"
 		},
 		"ext.bootstrapComponents.popover.fix": {
-			"dependencies": "ext.bootstrap.scripts",
+			"dependencies": "ext.bootstrapComponents.bootstrap",
 			"scripts": "ext.bootstrapComponents.popover.js"
 		},
 		"ext.bootstrapComponents.popover.vector-fix": {
 			"styles": "ext.bootstrapComponents.popover.vector-fix.css"
 		},
 		"ext.bootstrapComponents.tooltip.fix": {
-			"dependencies": "ext.bootstrap.scripts",
+			"dependencies": "ext.bootstrapComponents.bootstrap",
 			"scripts": "ext.bootstrapComponents.tooltip.js",
 			"styles": "ext.bootstrapComponents.tooltip.fix.css"
 		},

--- a/modules/ext.bootstrapComponents.bootstrap.js
+++ b/modules/ext.bootstrapComponents.bootstrap.js
@@ -1,0 +1,48 @@
+( function () {
+	'use strict';
+
+	// Resolve a Bootstrap component class by name: from the global that Extension:Bootstrap and most
+	// Bootstrap skins expose, or from the jQuery plugin bridge that some skins register instead (a
+	// plugin's Constructor is the native component class). Bootstrap registers each plugin under the
+	// component's lowercased name.
+	function resolve( name ) {
+		if ( window.bootstrap && window.bootstrap[ name ] ) {
+			return window.bootstrap[ name ];
+		}
+
+		const $ = window.jQuery;
+		const plugin = name.toLowerCase();
+		if ( $ && $.fn[ plugin ] && $.fn[ plugin ].Constructor ) {
+			return $.fn[ plugin ].Constructor;
+		}
+
+		return null;
+	}
+
+	// Run initialise( Component, root ) once the named Bootstrap component is available, on the
+	// initial content and again whenever content is re-rendered (VisualEditor, live preview). On a
+	// skin that provides its own Bootstrap nothing orders it before this code, so retry briefly.
+	function whenReady( name, initialise ) {
+		mw.hook( 'wikipage.content' ).add( function ( $content ) {
+			let attempts = 0;
+
+			( function attempt() {
+				const Component = resolve( name );
+				if ( Component ) {
+					initialise( Component, ( $content && $content[ 0 ] ) || document );
+					return;
+				}
+
+				if ( attempts++ < 20 ) {
+					setTimeout( attempt, 50 );
+					return;
+				}
+
+				mw.log.warn( 'BootstrapComponents: bootstrap.' + name + ' is not available.' );
+			}() );
+		} );
+	}
+
+	mw.libs = mw.libs || {};
+	mw.libs.bootstrapComponents = { whenReady: whenReady };
+}() );

--- a/modules/ext.bootstrapComponents.carousel.js
+++ b/modules/ext.bootstrapComponents.carousel.js
@@ -26,22 +26,9 @@
 ( function () {
 	'use strict';
 
-	// Wait for DOM to be ready
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', initCarousels );
-	} else {
-		initCarousels();
-	}
-
-	function initCarousels() {
-		if ( typeof bootstrap === 'undefined' || !bootstrap.Carousel ) {
-			// eslint-disable-next-line no-console
-			console.warn( 'BootstrapComponents: bootstrap.Carousel is not available; carousels will not cycle.' );
-			return;
-		}
-		const carouselElements = document.querySelectorAll( '.carousel' );
-		carouselElements.forEach( function ( element ) {
-			new bootstrap.Carousel( element );
+	mw.libs.bootstrapComponents.whenReady( 'Carousel', function ( Carousel, root ) {
+		root.querySelectorAll( '.carousel' ).forEach( function ( element ) {
+			Carousel.getOrCreateInstance( element );
 		} );
-	}
+	} );
 }() );

--- a/modules/ext.bootstrapComponents.modal.js
+++ b/modules/ext.bootstrapComponents.modal.js
@@ -5,24 +5,9 @@
 ( function () {
 	'use strict';
 
-	// Wait for DOM to be ready
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', initModals );
-	} else {
-		initModals();
-	}
-
-	function initModals() {
-		if ( typeof bootstrap === 'undefined' || !bootstrap.Modal ) {
-			// eslint-disable-next-line no-console
-			console.warn( 'BootstrapComponents: bootstrap.Modal is not available; modal triggers will not work.' );
-			return;
-		}
-		// Instantiate every .modal element so trigger clicks (or programmatic
-		// bootstrap.Modal.getOrCreateInstance(el).show()) work as expected.
-		const modalList = document.querySelectorAll( '.modal' );
-		modalList.forEach( function ( modalEl ) {
-			bootstrap.Modal.getOrCreateInstance( modalEl );
+	mw.libs.bootstrapComponents.whenReady( 'Modal', function ( Modal, root ) {
+		root.querySelectorAll( '.modal' ).forEach( function ( element ) {
+			Modal.getOrCreateInstance( element );
 		} );
-	}
+	} );
 }() );

--- a/modules/ext.bootstrapComponents.popover.js
+++ b/modules/ext.bootstrapComponents.popover.js
@@ -26,24 +26,9 @@
 ( function () {
 	'use strict';
 
-	// Wait for DOM to be ready
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', initPopovers );
-	} else {
-		initPopovers();
-	}
-
-	function initPopovers() {
-		if ( typeof bootstrap === 'undefined' || !bootstrap.Popover ) {
-			// eslint-disable-next-line no-console
-			console.warn( 'BootstrapComponents: bootstrap.Popover is not available; popover triggers will not work.' );
-			return;
-		}
-		const popoverTriggerList = document.querySelectorAll( '[data-bs-toggle="popover"]' );
-		popoverTriggerList.forEach( function ( popoverTriggerEl ) {
-			new bootstrap.Popover( popoverTriggerEl, {
-				html: true
-			} );
+	mw.libs.bootstrapComponents.whenReady( 'Popover', function ( Popover, root ) {
+		root.querySelectorAll( '[data-bs-toggle="popover"]' ).forEach( function ( element ) {
+			Popover.getOrCreateInstance( element, { html: true } );
 		} );
-	}
+	} );
 }() );

--- a/modules/ext.bootstrapComponents.tooltip.js
+++ b/modules/ext.bootstrapComponents.tooltip.js
@@ -26,22 +26,9 @@
 ( function () {
 	'use strict';
 
-	// Wait for DOM to be ready
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', initTooltips );
-	} else {
-		initTooltips();
-	}
-
-	function initTooltips() {
-		if ( typeof bootstrap === 'undefined' || !bootstrap.Tooltip ) {
-			// eslint-disable-next-line no-console
-			console.warn( 'BootstrapComponents: bootstrap.Tooltip is not available; tooltip triggers will not work.' );
-			return;
-		}
-		const tooltipTriggerList = document.querySelectorAll( '[data-bs-toggle="tooltip"]' );
-		tooltipTriggerList.forEach( function ( tooltipTriggerEl ) {
-			new bootstrap.Tooltip( tooltipTriggerEl );
+	mw.libs.bootstrapComponents.whenReady( 'Tooltip', function ( Tooltip, root ) {
+		root.querySelectorAll( '[data-bs-toggle="tooltip"]' ).forEach( function ( element ) {
+			Tooltip.getOrCreateInstance( element );
 		} );
-	}
+	} );
 }() );

--- a/src/BootstrapComponentsService.php
+++ b/src/BootstrapComponentsService.php
@@ -9,6 +9,11 @@ class BootstrapComponentsService
 {
 
 	/**
+	 * Skins that put Bootstrap on the page themselves.
+	 */
+	private const SKINS_WITH_OWN_BOOTSTRAP = [ 'medik', 'tweeki' ];
+
+	/**
 	 * List of active components on the page
 	 */
 	private array $activeComponents = [];
@@ -74,6 +79,10 @@ class BootstrapComponentsService
 	 */
 	public function vectorSkinInUse(): bool {
 		return in_array( strtolower( $this->getNameOfActiveSkin() ), [ 'vector', 'vector-2022' ] ) ;
+	}
+
+	public function skinProvidesBootstrap( string $skin ): bool {
+		return in_array( $skin, self::SKINS_WITH_OWN_BOOTSTRAP, true );
 	}
 
 	/**

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -6,6 +6,7 @@ use Bootstrap\BootstrapManager;
 use MediaWiki\Config\Config;
 use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
 use MediaWiki\Extension\BootstrapComponents\Hooks\ParserFirstCallInit;
+use MediaWiki\Hook\BeforePageDisplayHook;
 use MediaWiki\Hook\GalleryGetModesHook;
 use MediaWiki\Hook\ImageBeforeProduceHTMLHook;
 use MediaWiki\Hook\InternalParseBeforeLinksHook;
@@ -37,6 +38,7 @@ use StripState;
  * @since 5.0
  */
 class HooksHandler implements
+	BeforePageDisplayHook,
 	GalleryGetModesHook,
 	ImageBeforeProduceHTMLHook,
 	InternalParseBeforeLinksHook,
@@ -67,6 +69,21 @@ class HooksHandler implements
 		}
 
 		return true;
+	}
+
+	public function onBeforePageDisplay( $out, $skin ): void {
+		if ( $this->getBootstrapComponentsService()->skinProvidesBootstrap( $skin->getSkinName() ) ) {
+			return;
+		}
+
+		// Only where a page parsed content, which is where onParserAfterParse added the fix styles.
+		// This keeps Bootstrap off pages that render no wiki content, such as most special pages.
+		if ( !in_array( 'ext.bootstrapComponents.bootstrap.fix', $out->getModuleStyles(), true ) ) {
+			return;
+		}
+
+		$out->addModuleStyles( [ 'ext.bootstrap.styles' ] );
+		$out->addModules( [ 'ext.bootstrap.scripts' ] );
 	}
 
 	/**
@@ -194,11 +211,7 @@ class HooksHandler implements
 	 * @return bool
 	 */
 	public function onParserAfterParse( $parser, &$text, $stripState ): bool {
-		// once, this was only loaded, when a component was paced on the page. now, we load it always
-		// to keep the layout of all the wiki pages consistent.
 		$parser->getOutput()->addModuleStyles( [ 'ext.bootstrapComponents.bootstrap.fix' ] );
-		$parser->getOutput()->addModuleStyles( [ 'ext.bootstrap.styles' ] );
-		$parser->getOutput()->addModules( [ 'ext.bootstrap.scripts' ] );
 		$skin = $this->getBootstrapComponentsService()->getNameOfActiveSkin();
 		foreach ( $this->getBootstrapComponentsService()->getActiveComponents() as $activeComponent ) {
 			if ( !$this->getComponentLibrary()->isRegistered( $activeComponent ) ) {

--- a/tests/phpunit/Unit/BootstrapComponentsServiceTest.php
+++ b/tests/phpunit/Unit/BootstrapComponentsServiceTest.php
@@ -62,6 +62,23 @@ class BootstrapComponentsServiceTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider skinProvidesBootstrapProvider
+	 */
+	public function testSkinProvidesBootstrap( string $skin, bool $expected ) {
+		$instance = new BootstrapComponentsService( $this->getMockBuilder( Config::class )->getMock() );
+		$this->assertSame( $expected, $instance->skinProvidesBootstrap( $skin ) );
+	}
+
+	public static function skinProvidesBootstrapProvider(): array {
+		return [
+			'medik provides its own Bootstrap' => [ 'medik', true ],
+			'tweeki provides its own Bootstrap' => [ 'tweeki', true ],
+			'vector does not' => [ 'vector', false ],
+			'chameleon uses Extension:Bootstrap' => [ 'chameleon', false ],
+		];
+	}
+
+	/**
 	 * @throws ReflectionException
 	 */
 	public function testPrivateCanDetectSkinInUse() {

--- a/tests/phpunit/Unit/HooksHandlerTest.php
+++ b/tests/phpunit/Unit/HooksHandlerTest.php
@@ -6,7 +6,9 @@ use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\HooksHandler;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
+use MediaWiki\Output\OutputPage;
 use PHPUnit\Framework\TestCase;
+use Skin;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\HooksHandler
@@ -71,5 +73,53 @@ class HooksHandlerTest extends TestCase {
 	 */
 	public function testOnOutputPageParserOutput() {
 		$this->assertTrue( true );
+	}
+
+	public function testOnBeforePageDisplayLoadsBootstrapForNonProviderSkinWithParsedContent() {
+		$outputPage = $this->createMock( OutputPage::class );
+		$outputPage->method( 'getModuleStyles' )->willReturn( [ 'ext.bootstrapComponents.bootstrap.fix' ] );
+		$outputPage->expects( $this->once() )
+			->method( 'addModuleStyles' )
+			->with( [ 'ext.bootstrap.styles' ] );
+		$outputPage->expects( $this->once() )
+			->method( 'addModules' )
+			->with( [ 'ext.bootstrap.scripts' ] );
+
+		$this->newHooksHandler( false )->onBeforePageDisplay( $outputPage, $this->newSkin( 'vector' ) );
+	}
+
+	public function testOnBeforePageDisplaySkipsSkinThatProvidesBootstrap() {
+		$outputPage = $this->createMock( OutputPage::class );
+		$outputPage->expects( $this->never() )->method( 'addModuleStyles' );
+		$outputPage->expects( $this->never() )->method( 'addModules' );
+
+		$this->newHooksHandler( true )->onBeforePageDisplay( $outputPage, $this->newSkin( 'medik' ) );
+	}
+
+	public function testOnBeforePageDisplaySkipsPageThatParsedNoContent() {
+		$outputPage = $this->createMock( OutputPage::class );
+		$outputPage->method( 'getModuleStyles' )->willReturn( [] );
+		$outputPage->expects( $this->never() )->method( 'addModuleStyles' );
+		$outputPage->expects( $this->never() )->method( 'addModules' );
+
+		$this->newHooksHandler( false )->onBeforePageDisplay( $outputPage, $this->newSkin( 'vector' ) );
+	}
+
+	private function newHooksHandler( bool $skinProvidesBootstrap ): HooksHandler {
+		$service = $this->createMock( BootstrapComponentsService::class );
+		$service->method( 'skinProvidesBootstrap' )->willReturn( $skinProvidesBootstrap );
+
+		return new HooksHandler(
+			$service,
+			$this->createMock( ComponentLibrary::class ),
+			$this->createMock( NestingController::class ),
+		);
+	}
+
+	private function newSkin( string $skinName ): Skin {
+		$skin = $this->createMock( Skin::class );
+		$skin->method( 'getSkinName' )->willReturn( $skinName );
+
+		return $skin;
 	}
 }


### PR DESCRIPTION
For https://github.com/oetterer/BootstrapComponents/issues/70

Skins that bundle their own Bootstrap (for example Medik and Tweeki) also received
Extension:Bootstrap's copy, because BootstrapComponents loaded `ext.bootstrap.styles` and
`ext.bootstrap.scripts` unconditionally. That put two copies of Bootstrap on the page: two
stylesheets, whose cascade left stray list bullets on the skin's sidebar and dropdown menus, and
two scripts, each registering Bootstrap's document data-api, so one click was handled twice and the
skin's navbar and action dropdowns opened and immediately closed.

BootstrapComponents is the extension that pulls in Extension:Bootstrap, so it is the right place to
decide when that is needed. It now loads Extension:Bootstrap's Bootstrap only on skins that do not
provide their own (`BootstrapProvider::skinProvidesBootstrap`), from a `BeforePageDisplay` hook
where the active skin is known. On a skin that ships its own Bootstrap, nothing extra is loaded, so
there is a single copy. Extension:Bootstrap is unchanged and stays an honest, unconditional
provider.

Component initialisation goes through a small shared module (`ext.bootstrapComponents.bootstrap`)
that finds whichever Bootstrap is on the page: the `window.bootstrap` global that
Extension:Bootstrap and most Bootstrap skins expose, or the jQuery plugin bridge that some skins
register instead (a plugin's `Constructor` is the native component class). No skin's own module name
is referenced, the init calls read as plain Bootstrap (`Carousel.getOrCreateInstance( element )`),
and it runs on `wikipage.content`, so it also covers dynamically rendered content.

## Behaviour

Bootstrap still loads on every page that renders parsed content, as before. The `BeforePageDisplay`
hook adds it only when the page parsed BootstrapComponents content (the same scope in which the
parser hook runs), so pages that render no wiki content, such as most special pages, are unaffected,
exactly as before.

One deliberate change: the load moved off the `ParserOutput` (it has to, so the decision can depend
on the skin, which the shared parser cache cannot), so `api.php?action=parse` no longer lists
`ext.bootstrap.styles` / `ext.bootstrap.scripts` in its module lists. Ordinary page views,
VisualEditor and live preview are unaffected, since they render on a page that already loads
Bootstrap. Only a headless consumer that renders BootstrapComponents content fetched through
`action=parse`, outside a page, would need to load Bootstrap itself.

## Verification

Automated browser testing (Playwright) across Vector, Chameleon, Medik and Tweeki: provider skins
load a single Bootstrap, their sidebar and dropdown menus have no stray bullets, and navbar/action
dropdowns open and stay open; carousel, modal, popover, tooltip and accordion work on all four,
including through the jQuery bridge on Tweeki. A released-vs-branch comparison on Vector confirmed
the page scope matches: content pages, message-parsing special pages and `Special:ExpandTemplates`
load Bootstrap; chrome-only special pages do not. Unit tests cover the provider list.

> <sub>AI-authored, Claude Code, `Opus 4.8`; extensively steered by @malberts across many rounds, the approach was reworked several times; diff not yet human-reviewed; verified with unit tests and automated browser testing (Playwright) across four skins plus a released-vs-branch behavioural comparison; phpcs not run locally (the repo has no phpcs setup).</sub>
