### PR TITLE
Load Bootstrap once per skin

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,7 +6,7 @@ Released on TBD
 
 Fixes:
 * fix dropdown menus, accordions and other click-driven components on Medik and Tweeki
-* skins that provide their own Bootstrap (Medik and Tweeki) no longer also load Extension:Bootstrap's copy
+* skins that provide their own Bootstrap (Chameleon, Medik and Tweeki) no longer also load Extension:Bootstrap's copy
 
 Changes:
 * `api.php?action=parse` no longer lists the `ext.bootstrap.*` modules; anything rendering parsed content outside a normal page view must load Bootstrap itself

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,16 @@
 ## Release Notes
 
+### BootstrapComponents 6.1.0
+
+Released on TBD
+
+Fixes:
+* fix dropdown menus, accordions and other click-driven components on Medik and Tweeki
+* skins that provide their own Bootstrap (Medik and Tweeki) no longer also load Extension:Bootstrap's copy
+
+Changes:
+* `api.php?action=parse` no longer lists the `ext.bootstrap.*` modules; anything rendering parsed content outside a normal page view must load Bootstrap itself
+
 ### BootstrapComponents 6.0.1
 
 Released on 20-July-2026

--- a/extension.json
+++ b/extension.json
@@ -33,6 +33,9 @@
 		}
 	},
 	"Hooks": {
+		"BeforePageDisplay": {
+			"handler": "BootStrapHooks"
+		},
 		"GalleryGetModes": {
 			"handler": "BootStrapHooks"
 		},
@@ -92,7 +95,6 @@
 			"styles": "ext.bootstrapComponents.bootstrap.fix.css"
 		},
 		"ext.bootstrapComponents.bootstrap": {
-			"dependencies": "ext.bootstrap.scripts",
 			"packageFiles": [ "ext.bootstrapComponents.bootstrap.js" ]
 		},
 		"ext.bootstrapComponents.accordion.fix": {

--- a/modules/ext.bootstrapComponents.bootstrap.js
+++ b/modules/ext.bootstrapComponents.bootstrap.js
@@ -12,6 +12,29 @@ function getComponentClass( name ) {
 	return ( plugin && plugin.Constructor ) || null;
 }
 
+// Defers component initialization until the module carrying the active skin's Bootstrap has
+// loaded. A static ResourceLoader dependency cannot express this, since the module depends on
+// the skin. The modules are provided in a config variable instead. The callback runs for the
+// initial page content and again for every re-render (VisualEditor, live preview).
+function whenReady( callback ) {
+	const bootstrapModules = mw.config.get( 'wgBootstrapComponentsBootstrapModules' );
+	if ( !bootstrapModules ) {
+		mw.log.warn( 'BootstrapComponents: no Bootstrap modules were configured for this skin.' );
+		return;
+	}
+	if ( bootstrapModules.styles ) {
+		mw.loader.load( bootstrapModules.styles );
+	}
+	mw.loader.using( bootstrapModules.scripts ).then( function () {
+		mw.hook( 'wikipage.content' ).add( function ( $content ) {
+			callback( ( $content && $content[ 0 ] ) || document );
+		} );
+	}, function () {
+		mw.log.warn( 'BootstrapComponents: Bootstrap module "' + bootstrapModules.scripts + '" failed to load.' );
+	} );
+}
+
 module.exports = {
-	getComponentClass: getComponentClass
+	getComponentClass: getComponentClass,
+	whenReady: whenReady
 };

--- a/modules/ext.bootstrapComponents.carousel.js
+++ b/modules/ext.bootstrapComponents.carousel.js
@@ -36,7 +36,7 @@
 			return;
 		}
 		content.querySelectorAll( '.carousel' ).forEach( function ( element ) {
-			new Carousel( element );
+			Carousel.getOrCreateInstance( element );
 		} );
 	} );
 }() );

--- a/modules/ext.bootstrapComponents.carousel.js
+++ b/modules/ext.bootstrapComponents.carousel.js
@@ -26,25 +26,17 @@
 ( function () {
 	'use strict';
 
-	const { getComponentClass } = require( 'ext.bootstrapComponents.bootstrap' );
+	const { getComponentClass, whenReady } = require( 'ext.bootstrapComponents.bootstrap' );
 
-	// Wait for DOM to be ready
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', initCarousels );
-	} else {
-		initCarousels();
-	}
-
-	function initCarousels() {
+	whenReady( function ( content ) {
 		const Carousel = getComponentClass( 'Carousel' );
 		if ( !Carousel ) {
 			// eslint-disable-next-line no-console
 			console.warn( 'BootstrapComponents: bootstrap.Carousel is not available; carousels will not cycle.' );
 			return;
 		}
-		const carouselElements = document.querySelectorAll( '.carousel' );
-		carouselElements.forEach( function ( element ) {
+		content.querySelectorAll( '.carousel' ).forEach( function ( element ) {
 			new Carousel( element );
 		} );
-	}
+	} );
 }() );

--- a/modules/ext.bootstrapComponents.modal.js
+++ b/modules/ext.bootstrapComponents.modal.js
@@ -5,16 +5,9 @@
 ( function () {
 	'use strict';
 
-	const { getComponentClass } = require( 'ext.bootstrapComponents.bootstrap' );
+	const { getComponentClass, whenReady } = require( 'ext.bootstrapComponents.bootstrap' );
 
-	// Wait for DOM to be ready
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', initModals );
-	} else {
-		initModals();
-	}
-
-	function initModals() {
+	whenReady( function ( content ) {
 		const Modal = getComponentClass( 'Modal' );
 		if ( !Modal ) {
 			// eslint-disable-next-line no-console
@@ -23,9 +16,8 @@
 		}
 		// Instantiate every .modal element so trigger clicks (or programmatic
 		// bootstrap.Modal.getOrCreateInstance(el).show()) work as expected.
-		const modalList = document.querySelectorAll( '.modal' );
-		modalList.forEach( function ( modalEl ) {
+		content.querySelectorAll( '.modal' ).forEach( function ( modalEl ) {
 			Modal.getOrCreateInstance( modalEl );
 		} );
-	}
+	} );
 }() );

--- a/modules/ext.bootstrapComponents.popover.js
+++ b/modules/ext.bootstrapComponents.popover.js
@@ -26,27 +26,17 @@
 ( function () {
 	'use strict';
 
-	const { getComponentClass } = require( 'ext.bootstrapComponents.bootstrap' );
+	const { getComponentClass, whenReady } = require( 'ext.bootstrapComponents.bootstrap' );
 
-	// Wait for DOM to be ready
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', initPopovers );
-	} else {
-		initPopovers();
-	}
-
-	function initPopovers() {
+	whenReady( function ( content ) {
 		const Popover = getComponentClass( 'Popover' );
 		if ( !Popover ) {
 			// eslint-disable-next-line no-console
 			console.warn( 'BootstrapComponents: bootstrap.Popover is not available; popover triggers will not work.' );
 			return;
 		}
-		const popoverTriggerList = document.querySelectorAll( '[data-bs-toggle="popover"]' );
-		popoverTriggerList.forEach( function ( popoverTriggerEl ) {
-			new Popover( popoverTriggerEl, {
-				html: true
-			} );
+		content.querySelectorAll( '[data-bs-toggle="popover"]' ).forEach( function ( el ) {
+			new Popover( el, { html: true } );
 		} );
-	}
+	} );
 }() );

--- a/modules/ext.bootstrapComponents.popover.js
+++ b/modules/ext.bootstrapComponents.popover.js
@@ -36,7 +36,7 @@
 			return;
 		}
 		content.querySelectorAll( '[data-bs-toggle="popover"]' ).forEach( function ( el ) {
-			new Popover( el, { html: true } );
+			Popover.getOrCreateInstance( el, { html: true } );
 		} );
 	} );
 }() );

--- a/modules/ext.bootstrapComponents.tooltip.js
+++ b/modules/ext.bootstrapComponents.tooltip.js
@@ -26,25 +26,17 @@
 ( function () {
 	'use strict';
 
-	const { getComponentClass } = require( 'ext.bootstrapComponents.bootstrap' );
+	const { getComponentClass, whenReady } = require( 'ext.bootstrapComponents.bootstrap' );
 
-	// Wait for DOM to be ready
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', initTooltips );
-	} else {
-		initTooltips();
-	}
-
-	function initTooltips() {
+	whenReady( function ( content ) {
 		const Tooltip = getComponentClass( 'Tooltip' );
 		if ( !Tooltip ) {
 			// eslint-disable-next-line no-console
 			console.warn( 'BootstrapComponents: bootstrap.Tooltip is not available; tooltip triggers will not work.' );
 			return;
 		}
-		const tooltipTriggerList = document.querySelectorAll( '[data-bs-toggle="tooltip"]' );
-		tooltipTriggerList.forEach( function ( tooltipTriggerEl ) {
-			new Tooltip( tooltipTriggerEl );
+		content.querySelectorAll( '[data-bs-toggle="tooltip"]' ).forEach( function ( el ) {
+			new Tooltip( el );
 		} );
-	}
+	} );
 }() );

--- a/modules/ext.bootstrapComponents.tooltip.js
+++ b/modules/ext.bootstrapComponents.tooltip.js
@@ -36,7 +36,7 @@
 			return;
 		}
 		content.querySelectorAll( '[data-bs-toggle="tooltip"]' ).forEach( function ( el ) {
-			new Tooltip( el );
+			Tooltip.getOrCreateInstance( el );
 		} );
 	} );
 }() );

--- a/src/BootstrapComponentsService.php
+++ b/src/BootstrapComponentsService.php
@@ -119,9 +119,12 @@ class BootstrapComponentsService
 	}
 
 	/**
-	 * Skins that put the Bootstrap stylesheet on the page themselves.
+	 * Skins that put the Bootstrap stylesheet on the page themselves. Chameleon belongs here but
+	 * not in the scripts map: it registers Extension:Bootstrap's stylesheet under its own module
+	 * name (zzz.ext.bootstrap.styles), which ResourceLoader cannot deduplicate against
+	 * ext.bootstrap.styles, while its Bootstrap JavaScript is ext.bootstrap.scripts itself.
 	 */
-	private const SKINS_WITH_OWN_BOOTSTRAP_STYLES = [ 'medik', 'tweeki' ];
+	private const SKINS_WITH_OWN_BOOTSTRAP_STYLES = [ 'chameleon', 'medik', 'tweeki' ];
 
 	public function skinProvidesBootstrapStyles( string $skin ): bool {
 		return in_array( strtolower( $skin ), self::SKINS_WITH_OWN_BOOTSTRAP_STYLES, true );

--- a/src/BootstrapComponentsService.php
+++ b/src/BootstrapComponentsService.php
@@ -104,7 +104,9 @@ class BootstrapComponentsService
 		if ( $this->mainConfig->has( 'TweekiSkinCustomScriptModule' )
 			&& $this->mainConfig->get( 'TweekiSkinCustomScriptModule' )
 		) {
-			return $this->mainConfig->get( 'TweekiSkinCustomScriptModule' );
+			$module = $this->mainConfig->get( 'TweekiSkinCustomScriptModule' );
+			// A shape we do not mirror; fall back to Extension:Bootstrap's copy.
+			return is_string( $module ) ? $module : 'ext.bootstrap.scripts';
 		}
 		if ( $this->mainConfig->has( 'TweekiSkinUseCustomFiles' )
 			&& $this->mainConfig->get( 'TweekiSkinUseCustomFiles' )

--- a/src/BootstrapComponentsService.php
+++ b/src/BootstrapComponentsService.php
@@ -77,6 +77,57 @@ class BootstrapComponentsService
 	}
 
 	/**
+	 * Whether the given skin ships its own Bootstrap JavaScript.
+	 */
+	public function skinProvidesBootstrapScripts( string $skin ): bool {
+		return $this->getBootstrapScriptsModule( $skin ) !== 'ext.bootstrap.scripts';
+	}
+
+	/**
+	 * The ResourceLoader script module carrying the Bootstrap this skin should use: the skin's own on
+	 * skins that ship Bootstrap, Extension:Bootstrap's `ext.bootstrap.scripts` otherwise. The
+	 * component initialization waits on this module.
+	 */
+	public function getBootstrapScriptsModule( string $skin ): string {
+		return match ( strtolower( $skin ) ) {
+			'medik' => 'skins.medik.js',
+			'tweeki' => $this->getTweekiScriptModule(),
+			default => 'ext.bootstrap.scripts',
+		};
+	}
+
+	/**
+	 * Mirrors Tweeki's own script-module selection ({@see \SkinTweeki::initPage}), so we depend on
+	 * whichever module the running wiki actually loads Bootstrap through.
+	 */
+	private function getTweekiScriptModule(): string {
+		if ( $this->mainConfig->has( 'TweekiSkinCustomScriptModule' )
+			&& $this->mainConfig->get( 'TweekiSkinCustomScriptModule' )
+		) {
+			return $this->mainConfig->get( 'TweekiSkinCustomScriptModule' );
+		}
+		if ( $this->mainConfig->has( 'TweekiSkinUseCustomFiles' )
+			&& $this->mainConfig->get( 'TweekiSkinUseCustomFiles' )
+		) {
+			return 'skins.tweeki.custom.scripts';
+		}
+		return 'skins.tweeki.scripts';
+	}
+
+	public function getBootstrapStylesModule( string $skin ): ?string {
+		return $this->skinProvidesBootstrapStyles( $skin ) ? null : 'ext.bootstrap.styles';
+	}
+
+	/**
+	 * Skins that put the Bootstrap stylesheet on the page themselves.
+	 */
+	private const SKINS_WITH_OWN_BOOTSTRAP_STYLES = [ 'medik', 'tweeki' ];
+
+	public function skinProvidesBootstrapStyles( string $skin ): bool {
+		return in_array( strtolower( $skin ), self::SKINS_WITH_OWN_BOOTSTRAP_STYLES, true );
+	}
+
+	/**
 	 * @param bool $useConfig   set this to true, if we can't rely on {@see \RequestContext::getSkin}
 	 *
 	 * @return string

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -6,6 +6,7 @@ use Bootstrap\BootstrapManager;
 use MediaWiki\Config\Config;
 use MediaWiki\Extension\BootstrapComponents\Hooks\OutputPageParserOutput;
 use MediaWiki\Extension\BootstrapComponents\Hooks\ParserFirstCallInit;
+use MediaWiki\Hook\BeforePageDisplayHook;
 use MediaWiki\Hook\GalleryGetModesHook;
 use MediaWiki\Hook\ImageBeforeProduceHTMLHook;
 use MediaWiki\Hook\InternalParseBeforeLinksHook;
@@ -37,6 +38,7 @@ use StripState;
  * @since 5.0
  */
 class HooksHandler implements
+	BeforePageDisplayHook,
 	GalleryGetModesHook,
 	ImageBeforeProduceHTMLHook,
 	InternalParseBeforeLinksHook,
@@ -45,6 +47,12 @@ class HooksHandler implements
 	ParserFirstCallInitHook,
 	SetupAfterCacheHook
 {
+	/**
+	 * The styles fix module added on every parsed page. onBeforePageDisplay reads it as the
+	 * marker that the page rendered parsed content.
+	 */
+	private const BOOTSTRAP_FIX_MODULE = 'ext.bootstrapComponents.bootstrap.fix';
+
 	private Config $config;
 
 	public function __construct(
@@ -67,6 +75,40 @@ class HooksHandler implements
 		}
 
 		return true;
+	}
+
+	/**
+	 * Hook: BeforePageDisplay
+	 *
+	 * Loads Bootstrap for the active skin: Extension:Bootstrap's stylesheet and script are each
+	 * added only when the skin does not put its own on the page, so a single copy of each is on
+	 * the page, and only where the page rendered parsed content, the same scope in which
+	 * onParserAfterParse adds the styles fix. Component initialization waits on whichever module
+	 * carries this skin's Bootstrap, the modules are named in a config variable set on every page:
+	 * content can also arrive after page display (live preview on an edit page), and the init
+	 * scripts loaded with it read the variable and fetch the named module on demand.
+	 *
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/BeforePageDisplay
+	 */
+	public function onBeforePageDisplay( $out, $skin ): void {
+		$skinName = $skin->getSkinName();
+		$service = $this->getBootstrapComponentsService();
+
+		$out->addJsConfigVars( 'wgBootstrapComponentsBootstrapModules', [
+			'scripts' => $service->getBootstrapScriptsModule( $skinName ),
+			'styles' => $service->getBootstrapStylesModule( $skinName ),
+		] );
+
+		if ( !in_array( self::BOOTSTRAP_FIX_MODULE, $out->getModuleStyles(), true ) ) {
+			return;
+		}
+
+		if ( !$service->skinProvidesBootstrapStyles( $skinName ) ) {
+			$out->addModuleStyles( [ 'ext.bootstrap.styles' ] );
+		}
+		if ( !$service->skinProvidesBootstrapScripts( $skinName ) ) {
+			$out->addModules( [ 'ext.bootstrap.scripts' ] );
+		}
 	}
 
 	/**
@@ -194,11 +236,10 @@ class HooksHandler implements
 	 * @return bool
 	 */
 	public function onParserAfterParse( $parser, &$text, $stripState ): bool {
-		// once, this was only loaded, when a component was paced on the page. now, we load it always
-		// to keep the layout of all the wiki pages consistent.
-		$parser->getOutput()->addModuleStyles( [ 'ext.bootstrapComponents.bootstrap.fix' ] );
-		$parser->getOutput()->addModuleStyles( [ 'ext.bootstrap.styles' ] );
-		$parser->getOutput()->addModules( [ 'ext.bootstrap.scripts' ] );
+		// Always add the styles fix on parsed pages; it doubles as the marker onBeforePageDisplay
+		// reads to load Bootstrap for the active skin (which the shared, skin agnostic parser
+		// cache cannot decide).
+		$parser->getOutput()->addModuleStyles( [ self::BOOTSTRAP_FIX_MODULE ] );
 		$skin = $this->getBootstrapComponentsService()->getNameOfActiveSkin();
 		foreach ( $this->getBootstrapComponentsService()->getActiveComponents() as $activeComponent ) {
 			if ( !$this->getComponentLibrary()->isRegistered( $activeComponent ) ) {

--- a/tests/phpunit/Unit/BootstrapComponentsServiceTest.php
+++ b/tests/phpunit/Unit/BootstrapComponentsServiceTest.php
@@ -62,6 +62,88 @@ class BootstrapComponentsServiceTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider skinProvidesBootstrapScriptsProvider
+	 */
+	public function testSkinProvidesBootstrapScripts( string $skin, bool $expected ) {
+		$instance = new BootstrapComponentsService( $this->getMockBuilder( Config::class )->getMock() );
+		$this->assertSame( $expected, $instance->skinProvidesBootstrapScripts( $skin ) );
+	}
+
+	public static function skinProvidesBootstrapScriptsProvider(): array {
+		return [
+			'medik ships its own Bootstrap' => [ 'medik', true ],
+			'tweeki ships its own Bootstrap' => [ 'tweeki', true ],
+			'vector does not' => [ 'vector', false ],
+			'vector-2022 does not' => [ 'vector-2022', false ],
+			'chameleon uses Extension:Bootstrap scripts' => [ 'chameleon', false ],
+			'monobook does not' => [ 'monobook', false ],
+			'unknown skin does not' => [ 'serenity', false ],
+		];
+	}
+
+	/**
+	 * @dataProvider skinProvidesBootstrapStylesProvider
+	 */
+	public function testSkinProvidesBootstrapStyles( string $skin, bool $expected ) {
+		$instance = new BootstrapComponentsService( $this->getMockBuilder( Config::class )->getMock() );
+		$this->assertSame( $expected, $instance->skinProvidesBootstrapStyles( $skin ) );
+	}
+
+	public static function skinProvidesBootstrapStylesProvider(): array {
+		return [
+			'medik ships its own stylesheet' => [ 'medik', true ],
+			'tweeki ships its own stylesheet' => [ 'tweeki', true ],
+			'vector does not' => [ 'vector', false ],
+			'unknown skin does not' => [ 'serenity', false ],
+		];
+	}
+
+	/**
+	 * @dataProvider getBootstrapScriptsModuleProvider
+	 */
+	public function testGetBootstrapScriptsModule( string $skin, string $expected ) {
+		$instance = new BootstrapComponentsService( $this->getMockBuilder( Config::class )->getMock() );
+		$this->assertSame( $expected, $instance->getBootstrapScriptsModule( $skin ) );
+	}
+
+	public static function getBootstrapScriptsModuleProvider(): array {
+		return [
+			'medik uses its own skin module' => [ 'medik', 'skins.medik.js' ],
+			'vector uses Extension:Bootstrap' => [ 'vector', 'ext.bootstrap.scripts' ],
+			'chameleon uses Extension:Bootstrap' => [ 'chameleon', 'ext.bootstrap.scripts' ],
+			'unknown skin falls back to Extension:Bootstrap' => [ 'serenity', 'ext.bootstrap.scripts' ],
+		];
+	}
+
+	public function testGetBootstrapScriptsModuleForTweekiDefaultsToItsScriptModule() {
+		$instance = new BootstrapComponentsService( new TestConfig() );
+		$this->assertSame( 'skins.tweeki.scripts', $instance->getBootstrapScriptsModule( 'tweeki' ) );
+	}
+
+	public function testGetBootstrapScriptsModuleForTweekiTreatsFalseCustomModuleAsUnset() {
+		$config = new TestConfig();
+		$config->set( 'TweekiSkinCustomScriptModule', false );
+		$config->set( 'TweekiSkinUseCustomFiles', false );
+		$instance = new BootstrapComponentsService( $config );
+		$this->assertSame( 'skins.tweeki.scripts', $instance->getBootstrapScriptsModule( 'tweeki' ) );
+	}
+
+	public function testGetBootstrapScriptsModuleForTweekiUsesCustomFilesModule() {
+		$config = new TestConfig();
+		$config->set( 'TweekiSkinUseCustomFiles', true );
+		$instance = new BootstrapComponentsService( $config );
+		$this->assertSame( 'skins.tweeki.custom.scripts', $instance->getBootstrapScriptsModule( 'tweeki' ) );
+	}
+
+	public function testGetBootstrapScriptsModuleForTweekiHonorsConfiguredScriptModule() {
+		$config = new TestConfig();
+		$config->set( 'TweekiSkinCustomScriptModule', 'skins.tweeki.my.scripts' );
+		$config->set( 'TweekiSkinUseCustomFiles', true );
+		$instance = new BootstrapComponentsService( $config );
+		$this->assertSame( 'skins.tweeki.my.scripts', $instance->getBootstrapScriptsModule( 'tweeki' ) );
+	}
+
+	/**
 	 * @throws ReflectionException
 	 */
 	public function testPrivateCanDetectSkinInUse() {

--- a/tests/phpunit/Unit/BootstrapComponentsServiceTest.php
+++ b/tests/phpunit/Unit/BootstrapComponentsServiceTest.php
@@ -144,6 +144,13 @@ class BootstrapComponentsServiceTest extends TestCase {
 		$this->assertSame( 'skins.tweeki.my.scripts', $instance->getBootstrapScriptsModule( 'tweeki' ) );
 	}
 
+	public function testGetBootstrapScriptsModuleForTweekiFallsBackOnANonStringModule() {
+		$config = new TestConfig();
+		$config->set( 'TweekiSkinCustomScriptModule', [ 'skins.a', 'skins.b' ] );
+		$instance = new BootstrapComponentsService( $config );
+		$this->assertSame( 'ext.bootstrap.scripts', $instance->getBootstrapScriptsModule( 'tweeki' ) );
+	}
+
 	/**
 	 * @throws ReflectionException
 	 */

--- a/tests/phpunit/Unit/BootstrapComponentsServiceTest.php
+++ b/tests/phpunit/Unit/BootstrapComponentsServiceTest.php
@@ -91,6 +91,7 @@ class BootstrapComponentsServiceTest extends TestCase {
 
 	public static function skinProvidesBootstrapStylesProvider(): array {
 		return [
+			'chameleon registers its own copy of the stylesheet' => [ 'chameleon', true ],
 			'medik ships its own stylesheet' => [ 'medik', true ],
 			'tweeki ships its own stylesheet' => [ 'tweeki', true ],
 			'vector does not' => [ 'vector', false ],

--- a/tests/phpunit/Unit/HooksHandlerTest.php
+++ b/tests/phpunit/Unit/HooksHandlerTest.php
@@ -107,6 +107,17 @@ class HooksHandlerTest extends TestCase {
 		$this->newHooksHandler()->onBeforePageDisplay( $out, $this->newSkin( 'medik' ) );
 	}
 
+	public function testOnBeforePageDisplaySkipsOnlyTheStylesheetOnChameleon() {
+		$out = $this->createMock( OutputPage::class );
+		$out->method( 'getModuleStyles' )->willReturn( [ 'ext.bootstrapComponents.bootstrap.fix' ] );
+		$out->expects( $this->once() )->method( 'addJsConfigVars' )
+			->with( 'wgBootstrapComponentsBootstrapModules', [ 'scripts' => 'ext.bootstrap.scripts', 'styles' => null ] );
+		$out->expects( $this->never() )->method( 'addModuleStyles' );
+		$out->expects( $this->once() )->method( 'addModules' )
+			->with( [ 'ext.bootstrap.scripts' ] );
+
+		$this->newHooksHandler()->onBeforePageDisplay( $out, $this->newSkin( 'chameleon' ) );
+	}
 
 	public function testOnBeforePageDisplayOnlySetsTheConfigVariableWhenNoContentWasParsed() {
 		$out = $this->createMock( OutputPage::class );

--- a/tests/phpunit/Unit/HooksHandlerTest.php
+++ b/tests/phpunit/Unit/HooksHandlerTest.php
@@ -6,7 +6,12 @@ use MediaWiki\Extension\BootstrapComponents\BootstrapComponentsService;
 use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\HooksHandler;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
+use MediaWiki\Extension\BootstrapComponents\Tests\Fixtures\TestConfig;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOutput;
 use PHPUnit\Framework\TestCase;
+use Skin;
 
 /**
  * @covers  \MediaWiki\Extension\BootstrapComponents\HooksHandler
@@ -63,13 +68,69 @@ class HooksHandlerTest extends TestCase {
 		$this->assertEquals( 'MediaWiki\\Extension\\BootstrapComponents\\CarouselGallery', $modes['carousel'] );
 	}
 
-	/**
-	 * this hook is tested in
-	 * @see OutputPageParserOutputTest::testHookOutputPageParserOutput
-	 *
-	 * @return void
-	 */
-	public function testOnOutputPageParserOutput() {
-		$this->assertTrue( true );
+	public function testOnParserAfterParseAddsOnlyTheStylesFix() {
+		$parserOutput = new ParserOutput();
+		$parser = $this->createMock( Parser::class );
+		$parser->method( 'getOutput' )->willReturn( $parserOutput );
+		$text = '';
+
+		$this->newHooksHandler()->onParserAfterParse( $parser, $text, null );
+
+		$this->assertContains( 'ext.bootstrapComponents.bootstrap.fix', $parserOutput->getModuleStyles() );
+		$this->assertNotContains( 'ext.bootstrap.styles', $parserOutput->getModuleStyles() );
+		$this->assertNotContains( 'ext.bootstrap.scripts', $parserOutput->getModuleStyles() );
+		$this->assertNotContains( 'ext.bootstrap.styles', $parserOutput->getModules() );
+		$this->assertNotContains( 'ext.bootstrap.scripts', $parserOutput->getModules() );
+	}
+
+	public function testOnBeforePageDisplayLoadsExtensionBootstrapOnNonProviderContentPage() {
+		$out = $this->createMock( OutputPage::class );
+		$out->method( 'getModuleStyles' )->willReturn( [ 'ext.bootstrapComponents.bootstrap.fix' ] );
+		$out->expects( $this->once() )->method( 'addJsConfigVars' )
+			->with( 'wgBootstrapComponentsBootstrapModules', [ 'scripts' => 'ext.bootstrap.scripts', 'styles' => 'ext.bootstrap.styles' ] );
+		$out->expects( $this->once() )->method( 'addModuleStyles' )
+			->with( [ 'ext.bootstrap.styles' ] );
+		$out->expects( $this->once() )->method( 'addModules' )
+			->with( [ 'ext.bootstrap.scripts' ] );
+
+		$this->newHooksHandler()->onBeforePageDisplay( $out, $this->newSkin( 'vector' ) );
+	}
+
+	public function testOnBeforePageDisplaySkipsExtensionBootstrapOnSkinThatShipsItsOwn() {
+		$out = $this->createMock( OutputPage::class );
+		$out->method( 'getModuleStyles' )->willReturn( [ 'ext.bootstrapComponents.bootstrap.fix' ] );
+		$out->expects( $this->once() )->method( 'addJsConfigVars' )
+			->with( 'wgBootstrapComponentsBootstrapModules', [ 'scripts' => 'skins.medik.js', 'styles' => null ] );
+		$out->expects( $this->never() )->method( 'addModuleStyles' );
+		$out->expects( $this->never() )->method( 'addModules' );
+
+		$this->newHooksHandler()->onBeforePageDisplay( $out, $this->newSkin( 'medik' ) );
+	}
+
+
+	public function testOnBeforePageDisplayOnlySetsTheConfigVariableWhenNoContentWasParsed() {
+		$out = $this->createMock( OutputPage::class );
+		$out->method( 'getModuleStyles' )->willReturn( [] );
+		$out->expects( $this->once() )->method( 'addJsConfigVars' )
+			->with( 'wgBootstrapComponentsBootstrapModules', [ 'scripts' => 'ext.bootstrap.scripts', 'styles' => 'ext.bootstrap.styles' ] );
+		$out->expects( $this->never() )->method( 'addModules' );
+		$out->expects( $this->never() )->method( 'addModuleStyles' );
+
+		$this->newHooksHandler()->onBeforePageDisplay( $out, $this->newSkin( 'vector' ) );
+	}
+
+	private function newHooksHandler(): HooksHandler {
+		return new HooksHandler(
+			new BootstrapComponentsService( new TestConfig() ),
+			$this->createMock( ComponentLibrary::class ),
+			$this->createMock( NestingController::class ),
+		);
+	}
+
+	private function newSkin( string $skinName ): Skin {
+		$skin = $this->createMock( Skin::class );
+		$skin->method( 'getSkinName' )->willReturn( $skinName );
+
+		return $skin;
 	}
 }


### PR DESCRIPTION
For https://github.com/oetterer/BootstrapComponents/issues/70

Skins that bundle their own Bootstrap (for example Medik and Tweeki) also received
Extension:Bootstrap's copy, because BootstrapComponents loaded `ext.bootstrap.styles` and
`ext.bootstrap.scripts` unconditionally. Two copies of Bootstrap each registered Bootstrap's
document data-api, so one click was handled twice and the skin's navbar and action dropdowns
opened and immediately closed. Chameleon had the CSS half of the same problem: it registers
Extension:Bootstrap's stylesheet under its own module name (`zzz.ext.bootstrap.styles`), which
ResourceLoader cannot deduplicate against `ext.bootstrap.styles`, so pages carried the Bootstrap
CSS twice.

BootstrapComponents is the extension that pulls in Extension:Bootstrap, so it decides when that
copy is needed. From a `BeforePageDisplay` hook, where the active skin is known, it names the
modules carrying this skin's Bootstrap in a config variable: the script module to wait on
(`ext.bootstrap.scripts` on skins without their own, `skins.medik.js` on Medik, or Tweeki's
configured script module, honouring `$wgTweekiSkinCustomScriptModule`)
and the stylesheet module to load for dynamically rendered content, null on skins that provide
their own stylesheet. The shared
resolver module from #124 (already on master) waits on the script module with `mw.loader.using`,
then initialises the components on content render. On ordinary page views that module is one the
page already loads, so `using()` attaches to the in-flight load; on pages whose content arrives
later (live preview on an edit page) it is fetched on demand. On Tweeki, which
exposes no `window.bootstrap`, the components initialise through Bootstrap's jQuery plugin
bridge.

The stylesheet and the script are decided separately: Chameleon provides its own stylesheet (the
`zzz` clone) while consuming Extension:Bootstrap's scripts, so only the stylesheet is skipped
there; Medik and Tweeki provide both. The per-skin maps currently know Chameleon, Medik and
Tweeki; other Bootstrap-bundling skins keep today's behaviour until added, since the default
stays "load Extension:Bootstrap's copy". Whether a skin provides Bootstrap scripts is derived
from the same map that names the wait module, so those two decisions cannot drift apart. The
hook runs only where content was parsed, marked by the `ext.bootstrapComponents.bootstrap.fix`
styles module the parser adds on every parsed page; cache entries have carried that module since
5.2.0, so warm parser caches keep working across the upgrade.

Supersedes #122 and #113; both can be closed.

## Behaviour changes

- `api.php?action=parse` no longer lists `ext.bootstrap.styles` / `ext.bootstrap.scripts`; they
  load at page render, and no transitive dependency path to them remains. Page views,
  VisualEditor and live preview are unaffected.
- Tweeki pages no longer carry `window.bootstrap` (it came from Extension:Bootstrap's copy).
  Bootstrap's data-api markup is unaffected; only site scripts doing programmatic Bootstrap calls
  on Tweeki wikis are affected, and none are known.
- Component initialisation now also runs on re-rendered content (VisualEditor, live preview);
  previously only content already present when the init scripts first executed was initialised.
- Initialisation scans the rendered content area rather than the whole document. Hand-written
  Bootstrap component markup outside it (sitenotice, skin chrome) is no longer picked up;
  BootstrapComponents' own output always renders inside the content area.
- Pages served from a warm parser cache keep the old double load until they reparse or expire;
  the fix rolls out per page.

## Verification

Unit tests cover the per-skin module resolution (including Tweeki's config-driven module), the
styles and scripts provider checks, and the hook's load and marker decisions; CI (MW 1.43 through
master) is green. Automated browser testing (Playwright) on Vector, Chameleon, Medik and Tweeki:
provider skins load a single Bootstrap (`ext.bootstrap.scripts` stays unloaded), Chameleon
delivers the Bootstrap stylesheet once (`ext.bootstrap.styles` stays unloaded, its own copy
serves the page), all eleven components were exercised behaviourally on all four skins (44
checks; modals show exactly one backdrop, accordions fire single show/shown event pairs), every
chrome dropdown on Chameleon, Medik and Tweeki opens and stays open, `action=parse` output was
confirmed free of the `ext.bootstrap.*` modules, and the page scope matches released behaviour
(chrome-only special pages stay Bootstrap-free). Live preview was driven on the edit
page: first and repeated previews initialise their components and fetch the Bootstrap stylesheet
on demand, which is what publishing both modules on every page enables (`mw.loader.using` for
the script module, `mw.loader.load` for the stylesheet).
A VisualEditor edit on Medik was verified manually: after the in-place save, the accordion,
modal and tooltip in the updated content all function, with a clean console. Each skin was additionally
re-verified as the only installed skin, with identical results.

> <sub>AI-authored, Claude Code (`Fable 5`, with `Opus 4.8` subagents); design steered by @malberts across many rounds; diff not human-reviewed; verified with unit tests, CI PHPUnit (MW 1.43 through master) and automated browser testing (Playwright) across the four skins above.</sub>
