### PR TITLE
Route component modules to the matching ResourceLoader queue

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,12 @@
 ## Release Notes
 
+### BootstrapComponents 6.1.1
+
+Released on TBD
+
+Fixes:
+* stop logging `Unexpected general module ... in styles queue.` on pages using a modal, carousel, tooltip or popover
+
 ### BootstrapComponents 6.1.0
 
 Released on 21-July-2026

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -247,8 +247,8 @@ class HooksHandler implements
 			if ( !$this->getComponentLibrary()->isRegistered( $activeComponent ) ) {
 				continue;
 			}
-			foreach ( $this->getComponentLibrary()->getModulesFor( $activeComponent, 'vector' ) as $module ) {
-				$this->addModuleToMatchingQueue( $parser->getOutput(), $module );
+			foreach ( $this->getComponentLibrary()->getModulesFor( $activeComponent, 'vector' ) as $moduleName ) {
+				$this->addModuleToMatchingQueue( $parser->getOutput(), $moduleName );
 			}
 		}
 		return true;
@@ -256,17 +256,18 @@ class HooksHandler implements
 
 	/**
 	 * ResourceLoader discards anything but a styles-only module from the styles queue, so a module
-	 * carrying scripts or dependencies has to go to the general queue, which delivers its styles too.
+	 * that also carries scripts, dependencies, messages or templates has to go to the general
+	 * queue, which delivers its styles too.
 	 */
-	private function addModuleToMatchingQueue( ParserOutput $parserOutput, string $module ): void {
-		$registeredModule = MediaWikiServices::getInstance()->getResourceLoader()->getModule( $module );
+	private function addModuleToMatchingQueue( ParserOutput $parserOutput, string $moduleName ): void {
+		$module = MediaWikiServices::getInstance()->getResourceLoader()->getModule( $moduleName );
 
-		if ( $registeredModule && $registeredModule->getType() === Module::LOAD_STYLES ) {
-			$parserOutput->addModuleStyles( [ $module ] );
+		if ( $module !== null && $module->getType() === Module::LOAD_STYLES ) {
+			$parserOutput->addModuleStyles( [ $moduleName ] );
 			return;
 		}
 
-		$parserOutput->addModules( [ $module ] );
+		$parserOutput->addModules( [ $moduleName ] );
 	}
 
 	/**

--- a/src/HooksHandler.php
+++ b/src/HooksHandler.php
@@ -16,6 +16,8 @@ use MediaWiki\Hook\ParserFirstCallInitHook;
 use MediaWiki\Hook\SetupAfterCacheHook;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\ResourceLoader\Module;
 use SMW\Utils\File;
 use StripState;
 
@@ -246,11 +248,25 @@ class HooksHandler implements
 				continue;
 			}
 			foreach ( $this->getComponentLibrary()->getModulesFor( $activeComponent, 'vector' ) as $module ) {
-				$parser->getOutput()->addModuleStyles( [ $module ] );
-				$parser->getOutput()->addModules( [ $module ] );
+				$this->addModuleToMatchingQueue( $parser->getOutput(), $module );
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * ResourceLoader discards anything but a styles-only module from the styles queue, so a module
+	 * carrying scripts or dependencies has to go to the general queue, which delivers its styles too.
+	 */
+	private function addModuleToMatchingQueue( ParserOutput $parserOutput, string $module ): void {
+		$registeredModule = MediaWikiServices::getInstance()->getResourceLoader()->getModule( $module );
+
+		if ( $registeredModule && $registeredModule->getType() === Module::LOAD_STYLES ) {
+			$parserOutput->addModuleStyles( [ $module ] );
+			return;
+		}
+
+		$parserOutput->addModules( [ $module ] );
 	}
 
 	/**

--- a/tests/phpunit/Unit/HooksHandlerTest.php
+++ b/tests/phpunit/Unit/HooksHandlerTest.php
@@ -7,9 +7,11 @@ use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\HooksHandler;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\Tests\Fixtures\TestConfig;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOutput;
+use MediaWiki\ResourceLoader\Module;
 use PHPUnit\Framework\TestCase;
 use Skin;
 
@@ -81,6 +83,55 @@ class HooksHandlerTest extends TestCase {
 		$this->assertNotContains( 'ext.bootstrap.scripts', $parserOutput->getModuleStyles() );
 		$this->assertNotContains( 'ext.bootstrap.styles', $parserOutput->getModules() );
 		$this->assertNotContains( 'ext.bootstrap.scripts', $parserOutput->getModules() );
+	}
+
+	public function testOnParserAfterParseKeepsGeneralModulesOutOfTheStylesQueue() {
+		$parserOutput = $this->parserOutputAfterParsingWith( 'modal' );
+
+		$this->assertNotEmpty( $parserOutput->getModules(), 'the active component contributed no modules' );
+		$this->assertSame( [], $this->modulesOfType( $parserOutput->getModuleStyles(), Module::LOAD_GENERAL ) );
+	}
+
+	public function testOnParserAfterParseKeepsStylesOnlyModulesOutOfTheGeneralQueue() {
+		$parserOutput = $this->parserOutputAfterParsingWith( 'modal' );
+
+		$this->assertNotEmpty( $parserOutput->getModules(), 'the active component contributed no modules' );
+		$this->assertSame( [], $this->modulesOfType( $parserOutput->getModules(), Module::LOAD_STYLES ) );
+	}
+
+	private function parserOutputAfterParsingWith( string $componentName ): ParserOutput {
+		$bootstrapComponentsService = new BootstrapComponentsService( new TestConfig() );
+		$bootstrapComponentsService->registerComponentAsActive( $componentName );
+		$parserOutput = new ParserOutput();
+		$parser = $this->createMock( Parser::class );
+		$parser->method( 'getOutput' )->willReturn( $parserOutput );
+		$text = '';
+
+		$hooksHandler = new HooksHandler(
+			$bootstrapComponentsService,
+			new ComponentLibrary(),
+			$this->createMock( NestingController::class ),
+		);
+		$hooksHandler->onParserAfterParse( $parser, $text, null );
+
+		return $parserOutput;
+	}
+
+	/**
+	 * @param string[] $moduleNames
+	 * @return string[]
+	 */
+	private function modulesOfType( array $moduleNames, string $type ): array {
+		$resourceLoader = MediaWikiServices::getInstance()->getResourceLoader();
+
+		return array_values( array_filter(
+			$moduleNames,
+			static function ( string $moduleName ) use ( $resourceLoader, $type ): bool {
+				$module = $resourceLoader->getModule( $moduleName );
+
+				return $module !== null && $module->getType() === $type;
+			}
+		) );
 	}
 
 	public function testOnBeforePageDisplayLoadsExtensionBootstrapOnNonProviderContentPage() {

--- a/tests/phpunit/Unit/HooksHandlerTest.php
+++ b/tests/phpunit/Unit/HooksHandlerTest.php
@@ -7,11 +7,9 @@ use MediaWiki\Extension\BootstrapComponents\ComponentLibrary;
 use MediaWiki\Extension\BootstrapComponents\HooksHandler;
 use MediaWiki\Extension\BootstrapComponents\NestingController;
 use MediaWiki\Extension\BootstrapComponents\Tests\Fixtures\TestConfig;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOutput;
-use MediaWiki\ResourceLoader\Module;
 use PHPUnit\Framework\TestCase;
 use Skin;
 
@@ -85,21 +83,21 @@ class HooksHandlerTest extends TestCase {
 		$this->assertNotContains( 'ext.bootstrap.scripts', $parserOutput->getModules() );
 	}
 
-	public function testOnParserAfterParseKeepsGeneralModulesOutOfTheStylesQueue() {
-		$parserOutput = $this->parserOutputAfterParsingWith( 'modal' );
+	public function testOnParserAfterParseSplitsComponentModulesByType() {
+		$parserOutput = $this->parserOutputWithActiveComponent( 'modal' );
 
-		$this->assertNotEmpty( $parserOutput->getModules(), 'the active component contributed no modules' );
-		$this->assertSame( [], $this->modulesOfType( $parserOutput->getModuleStyles(), Module::LOAD_GENERAL ) );
+		$this->assertSame(
+			[
+				'ext.bootstrapComponents.bootstrap.fix',
+				'ext.bootstrapComponents.button.fix',
+				'ext.bootstrapComponents.modal.vector-fix',
+			],
+			$parserOutput->getModuleStyles()
+		);
+		$this->assertSame( [ 'ext.bootstrapComponents.modal.fix' ], $parserOutput->getModules() );
 	}
 
-	public function testOnParserAfterParseKeepsStylesOnlyModulesOutOfTheGeneralQueue() {
-		$parserOutput = $this->parserOutputAfterParsingWith( 'modal' );
-
-		$this->assertNotEmpty( $parserOutput->getModules(), 'the active component contributed no modules' );
-		$this->assertSame( [], $this->modulesOfType( $parserOutput->getModules(), Module::LOAD_STYLES ) );
-	}
-
-	private function parserOutputAfterParsingWith( string $componentName ): ParserOutput {
+	private function parserOutputWithActiveComponent( string $componentName ): ParserOutput {
 		$bootstrapComponentsService = new BootstrapComponentsService( new TestConfig() );
 		$bootstrapComponentsService->registerComponentAsActive( $componentName );
 		$parserOutput = new ParserOutput();
@@ -115,23 +113,6 @@ class HooksHandlerTest extends TestCase {
 		$hooksHandler->onParserAfterParse( $parser, $text, null );
 
 		return $parserOutput;
-	}
-
-	/**
-	 * @param string[] $moduleNames
-	 * @return string[]
-	 */
-	private function modulesOfType( array $moduleNames, string $type ): array {
-		$resourceLoader = MediaWikiServices::getInstance()->getResourceLoader();
-
-		return array_values( array_filter(
-			$moduleNames,
-			static function ( string $moduleName ) use ( $resourceLoader, $type ): bool {
-				$module = $resourceLoader->getModule( $moduleName );
-
-				return $module !== null && $module->getType() === $type;
-			}
-		) );
 	}
 
 	public function testOnBeforePageDisplayLoadsExtensionBootstrapOnNonProviderContentPage() {


### PR DESCRIPTION
`onParserAfterParse` added every active component's modules to both queues. ResourceLoader accepts only
styles-only modules in the styles queue, so `modal.fix`, `carousel.fix`, `tooltip.fix` and `popover.fix` each
logged `Unexpected general module "..." in styles queue.` on every page view that activated their component.
The first three also lost their stylesheet from the render-blocking `<head>` output; `popover.fix` carries no
stylesheet, so for it only the log line was affected.

Route each module to the queue matching its type. Styles-only modules keep their render-blocking `<link>`;
modules carrying scripts or dependencies go to the general queue, which delivers their styles too.

Dropping the `addModuleStyles()` call instead also silences the error, but it demotes the styles-only modules
to JS-delivered CSS, trading log noise for a flash of unstyled content on elements visible at first paint.

Splitting the four combined modules into separate styles and script modules is what would restore
render-blocking CSS for them. That is not done here and is not currently tracked: #90 covers the per-skin
resolution mechanism and #118 the stylesheet contents, so neither carries it. The hardcoded `'vector'`
argument and the unused `$skin` on the adjacent lines do belong to #90.

No remaining call site can put a general module into the styles queue, so the logged error is gone for
good: the only other additions there are `ext.bootstrap.styles` and `ext.bootstrapComponents.bootstrap.fix`,
both styles-only.

The inverse case is untouched. `Hooks/OutputPageParserOutput` queues `ext.bootstrapComponents.vector-fix` with
`addModules()`, and that module is declared for no component, so no path ever puts it in the styles queue. Its
rules are page-wide (`html { font-size }`, `body.skin-vector *, *::before, *::after { box-sizing: initial }`),
so on Vector they take effect only once the module has loaded. `AbstractComponent::augmentParserOutput()` also
adds a rendered component's modules with `addModules()` regardless of type, through a `ParserOutputHelper`
bound to whichever parser reached `ParserFirstCallInit` first; those additions are not visible in the queues of
a rendered page.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; started from a production log excerpt supplied by
> @malberts, approach narrowed once after a challenge on minimality, then revised after a four-lens AI review;
> diff not yet human-reviewed; unit suite run locally against MW 1.43, and the log line reproduced and then
> confirmed gone on a real page render.</sub>
